### PR TITLE
Replace native 'which' with Ruby version.

### DIFF
--- a/lib/overcommit/hook_specific_check.rb
+++ b/lib/overcommit/hook_specific_check.rb
@@ -69,8 +69,15 @@ module Overcommit
         Overcommit::Utils.modified_files
       end
 
-      def in_path?(cmd)
-        system("which #{cmd} &> /dev/null")
+      def in_path(cmd)
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+        ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+          exts.each { |ext|
+            exe = File.join(path, "#{cmd}#{ext}")
+            return exe if File.executable? exe
+          }
+        end
+        return nil
       end
 
       def commit_message_file


### PR DESCRIPTION
Courtesy of http://stackoverflow.com/questions/2108727/which-in-ruby-checking-if-program-exists-in-path-from-ruby.
