### PR TITLE
Add Config Options to Pre Commit Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ handy shell scripts:
 - `prepare-commit-msg` sets up your commit message to include additional author
   information and note submodule changes when updating.
 
+##Configuration
+
+Config files can be created in `.git/hooks/config/testname*`
+  
+Supported configs include:
+
+    >> tree .git/hooks/config
+    .git/hooks/config
+    └── coffeelint.json
+    
+    
 ## Uninstallation
 
 If you'd like to remove the hooks from a repository, just pass the `--uninstall`

--- a/lib/overcommit/hook_specific_check.rb
+++ b/lib/overcommit/hook_specific_check.rb
@@ -99,6 +99,12 @@ module Overcommit
           take_while { |line| !line.start_with?('diff --git') }
       end
 
+      def config_file
+        filename = self.class.name.split('::').last.downcase
+        dir = Dir.glob(".git/hooks/config/#{filename}*") #any extension
+        dir.last unless dir.empty?
+      end
+
       class << self
         def file_type(*types)
           self.filetypes = types

--- a/lib/overcommit/plugins/pre_commit/coffee_lint.rb
+++ b/lib/overcommit/plugins/pre_commit/coffee_lint.rb
@@ -3,13 +3,17 @@ module Overcommit::GitHook
     include HookRegistry
     file_type :coffee
 
+    def config
+      "-f #{config_file}" if config_file
+    end
+
     def run_check
       unless in_path? 'coffeelint'
         return :warn, 'Run `npm install -g coffeelint`'
       end
 
       paths  = staged.collect(&:path).join(' ')
-      output = `coffeelint --quiet #{paths}`.split("\n")
+      output = `coffeelint #{config} --quiet #{paths}`.split("\n")
       return ($?.success? ? :good : :bad), output
     end
   end


### PR DESCRIPTION
- hook specific check:  add config_file
       => returns .git/hooks/config/classname\* if it exists
- coffee_list
       => pass in -f config if the config exists
