### PR TITLE
Find and use .rubocop.yml for staged files

### DIFF
--- a/lib/overcommit/plugins/pre_commit/ruby_style.rb
+++ b/lib/overcommit/plugins/pre_commit/ruby_style.rb
@@ -55,7 +55,7 @@ module Overcommit::GitHook
       dir = staged_file.original_path.split('/')
       file = ''
       file = rubo_file(dir) while !File.exists?(file) && dir.pop
-      file
+      File.exists?(file) ? file : nil
     end
 
     def rubo_file(dir)


### PR DESCRIPTION
This is largely an itchy-scratchy patch. 

When checking a file, rubocop will look for a '.rubocop.yml' file in the current directory and the parent directories. Since overcommit checks the staged temp file, rubocop will never find the configuration from the working copy.

I call rubocop separately for each file, and try to figure out if a 'rubocop.yml' exists somewhere in the path to that file. If so, it's added to the rubocop call.

No tests for the time being, but the code isn't that big either. 

(The patch does not fix the problem that rubocop will not be able to use the exclude paths from the configuration when working with a temp file from the index.)

Feel free to merge.
