### PR TITLE
Fix rubocop.yml not found in top-level directory

### DIFF
--- a/lib/overcommit/plugins/pre_commit/ruby_style.rb
+++ b/lib/overcommit/plugins/pre_commit/ruby_style.rb
@@ -54,11 +54,15 @@ module Overcommit::GitHook
       end
     end
 
+    def possible_files(file_path)
+      files = Pathname.new(file_path).enum_for(:ascend)
+                      .map { |path| path + '.rubocop.yml' }
+      files << Pathname.new('.rubocop.yml')
+    end
+
     def rubocop_yml_for(staged_file)
-      Pathname.new(staged_file.original_path).
-               enum_for(:ascend).
-               map { |path| path + '.rubocop.yml' }.
-               find { |path| path.file? }
+      possible_files(staged_file.original_path)
+               .find { |path| path.file? }
     end
   end
 end

--- a/spec/plugins/pre_commit/ruby_style_spec.rb
+++ b/spec/plugins/pre_commit/ruby_style_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Overcommit::GitHook::RubyStyle do
+
+  let(:ruby_style) { Overcommit::GitHook::RubyStyle.new }
+
+  describe "#possible_files" do
+
+    it 'should return all possible paths for the rubocop config file' do
+      result = ruby_style.send(:possible_files, 'foo/bar')
+      result.map(&:to_s).should eq ['foo/bar/.rubocop.yml',
+                                    'foo/.rubocop.yml',
+                                    '.rubocop.yml']
+    end
+
+  end
+
+  describe "#rubocop_yml_for" do
+
+    let(:staged_file) { stub(original_path: 'some/dir') }
+    let(:existing) { stub(file?: true) }
+    let(:non_existing) { stub(file?: false) }
+
+    it "returns the file that exists" do
+      ruby_style.should_receive(:possible_files).with('some/dir').and_return([existing, non_existing])
+      ruby_style.send(:rubocop_yml_for, staged_file).should eq existing
+    end
+
+    it "returns nil if none of the files exist" do
+      ruby_style.stub(possible_files: [non_existing])
+      ruby_style.send(:rubocop_yml_for, staged_file).should be_nil
+    end
+
+  end
+
+  describe "#rubocop_config_mapping" do
+
+    it "inserts the staged files into a hash" do
+      file = stub(path: 'foobar/file.x')
+      ruby_style.stub(staged: [file])
+      ruby_style.should_receive(:rubocop_yml_for).with(file).and_return('boing')
+      ruby_style.send(:rubocop_config_mapping).should eq({ 'boing' => ['foobar/file.x'] })
+    end
+
+  end
+end


### PR DESCRIPTION
Follow up to my last pull request. Pathname#ascend stops at the last path element. Thus the rubocop yml in the top-level directory was not found.

This should fix it, plus a few simple specs.
