### PR TITLE
Exclude submodules from modified_files

### DIFF
--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -50,7 +50,7 @@ module Overcommit
       # Get a list of staged Added, Copied, or Modified files (ignore renames
       # and deletions, since there should be nothing to check).
       def modified_files
-        `git diff --cached --name-only --diff-filter=ACM`.split "\n"
+        `git diff --cached --name-only --diff-filter=ACM --ignore-submodules=all`.split "\n"
       end
 
     private

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Overcommit::Utils do
+  describe '.modified_files' do
+    subject { Overcommit::Utils.modified_files }
+
+    it 'does not include submodules' do
+      submodule = repo do
+        File.write 'foo', 'bar'
+        `git add foo`
+        `git commit -m "Initial commit"`
+      end
+
+      repo do
+        `git submodule add #{submodule} test-sub`
+        `git add .`
+        expect(subject).to_not include('test-sub')
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
The command to extract modified files is currently `git diff --cached --name-only --diff-filter=ACM`, which includes any added submodule directories. This confuses eg. the whitespace checker, which tries to do `git diff` on them producing messages such as `bad object :libs/iberty`. I don't think having submodule directories in the list is useful, as there's no content to check there anyway, so this patch removes them.
