### PR TITLE
Display all error messages for TextWidth.

### DIFF
--- a/lib/overcommit/hook/commit_msg/text_width.rb
+++ b/lib/overcommit/hook/commit_msg/text_width.rb
@@ -3,21 +3,27 @@ module Overcommit::Hook::CommitMsg
   # under the preferred limits.
   class TextWidth < Base
     def run
+      errors = []
+
       max_subject_width = @config['max_subject_width']
       max_body_width = @config['max_body_width']
 
       if commit_message_lines.first.size > max_subject_width
-        return :warn, "Please keep the subject <= #{max_subject_width} characters"
+        errors << "Please keep the subject <= #{max_subject_width} characters"
       end
 
-      commit_message_lines.each_with_index do |line, index|
-        chomped = line.chomp
-        if chomped.size > max_body_width
-          return :warn, "Line #{index + 1} of commit message has > " <<
-                        "#{max_body_width} characters, please hard wrap: " <<
-                        "'#{chomped}'"
+      if commit_message_lines.size > 2
+        commit_message_lines[2..-1].each_with_index do |line, index|
+          chomped = line.chomp
+          if chomped.size > max_body_width
+            error = "Line #{index + 3} of commit message has > " <<
+                    "#{max_body_width} characters"
+            errors << error
+          end
         end
       end
+
+      return :warn, errors.join("\n") if errors.any?
 
       :good
     end

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -28,7 +28,7 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
       This line is longer than 72 characters which is clearly be seen by count.
     MSG
 
-    it { should warn /72 char/ }
+    it { should warn('Line 3 of commit message has > 72 characters') }
   end
 
   context 'when all lines in the message are fewer than 72 characters' do
@@ -41,6 +41,21 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
     MSG
 
     it { should pass }
+  end
+
+  context 'when subject and a line in the message is longer than the limits' do
+    let(:commit_msg) { <<-MSG }
+      A subject line that is way too long. A subject line that is way too long.
+
+      A message line that is way too long. A message line that is way too long.
+    MSG
+
+    it do
+      should warn(
+        "Please keep the subject <= 60 characters\n" <<
+        "Line 3 of commit message has > 72 characters"
+      )
+    end
   end
 
   context 'when custom lengths are specified' do
@@ -74,7 +89,7 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
         This line is longer than 80 characters which can clearly be seen by counting the number of characters.
       MSG
 
-      it { should warn /80 char/ }
+      it { should warn('Line 3 of commit message has > 80 characters') }
     end
 
     context 'when all lines in the message are fewer than 80 characters' do
@@ -87,6 +102,21 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
       MSG
 
       it { should pass }
+    end
+
+    context 'when subject and a line in the message is longer than the limits' do
+      let(:commit_msg) { <<-MSG }
+        A subject line that is way too long. A subject line that is way too long.
+
+        A message line that is way too long. A message line that is way too long. A message line that is way too long.
+      MSG
+
+      it do
+        should warn(
+          "Please keep the subject <= 70 characters\n" <<
+          "Line 3 of commit message has > 80 characters"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Given that my subject and body lines are over the maximum limit
When I save the commit
Then I should be able to see warnings for each of the errors
