### PR TITLE
Return :warn instead of :fail on BundleCheck

### DIFF
--- a/lib/overcommit/hook/post_checkout/bundle_check.rb
+++ b/lib/overcommit/hook/post_checkout/bundle_check.rb
@@ -7,7 +7,7 @@ module Overcommit::Hook::PostCheckout
         return :warn, 'bundler not installed -- run `gem install bundler`'
       end
 
-      return :bad if dependencies_changed? && !dependencies_satisfied?
+      return :warn if dependencies_changed? && !dependencies_satisfied?
 
       :good
     end

--- a/spec/overcommit/hook/post_checkout/bundle_check_spec.rb
+++ b/spec/overcommit/hook/post_checkout/bundle_check_spec.rb
@@ -43,7 +43,7 @@ describe Overcommit::Hook::PostCheckout::BundleCheck do
     context 'and the dependencies are not satisfied' do
       let(:satisfied) { false }
 
-      it { should fail_check }
+      it { should warn }
     end
   end
 end


### PR DESCRIPTION
When rebasing, returning `:fail` will abort rebase and the repository ends up with a detached HEAD. Rebase becomes impossible unless you install the needed gems first.

My solution for this is to return `:warn` since I think the bundle check status is a nice to know and shouldn't stop a rebase.
