### PR TITLE
Add CLI option to list available hooks

### DIFF
--- a/lib/overcommit/configuration.rb
+++ b/lib/overcommit/configuration.rb
@@ -1,6 +1,13 @@
 module Overcommit
   # Stores configuration for Overcommit and the hooks it runs.
   class Configuration
+    # Keys in `@hash` that do not represent a hook context. These must be
+    # removed to determine the available contexts for the repo.
+    NON_CONTEXT_KEYS = %w[
+      plugin_directory
+      verify_plugin_signatures
+    ]
+
     # Creates a configuration from the given hash.
     def initialize(hash)
       @hash = ConfigurationValidator.new.validate(hash)
@@ -19,6 +26,19 @@ module Overcommit
 
     def verify_plugin_signatures?
       @hash['verify_plugin_signatures'] != false
+    end
+
+    # Returns information on all hooks for the contexts with the given names.
+    def all_hooks
+      context_names = @hash.keys.reject { |k| NON_CONTEXT_KEYS.include? k }
+
+      hooks = {}
+      context_names.each do |context_name|
+        hook_names = @hash[context_name].keys.reject { |name| name == 'ALL' }
+        hooks[Overcommit::Utils.camel_case(context_name)] = hook_names
+      end
+
+      hooks
     end
 
     # Returns the built-in hooks that have been enabled for a hook type.
@@ -66,7 +86,18 @@ module Overcommit
       end
     end
 
-    protected
+    def hook_enabled?(hook_context, hook_name)
+      hook_type = hook_context.hook_class_name
+      individual_enabled = @hash[hook_type][hook_name]['enabled']
+      return individual_enabled unless individual_enabled.nil?
+
+      all_enabled = @hash[hook_type]['ALL']['enabled']
+      return all_enabled unless all_enabled.nil?
+
+      true
+    end
+
+  protected
 
     attr_reader :hash
 
@@ -90,17 +121,6 @@ module Overcommit
     def hook_exists?(hook_context, hook_name)
       built_in_hook?(hook_context, hook_name) ||
         plugin_hook?(hook_context, hook_name)
-    end
-
-    def hook_enabled?(hook_context, hook_name)
-      hook_type = hook_context.hook_class_name
-      individual_enabled = @hash[hook_type][hook_name]['enabled']
-      return individual_enabled unless individual_enabled.nil?
-
-      all_enabled = @hash[hook_type]['ALL']['enabled']
-      return all_enabled unless all_enabled.nil?
-
-      true
     end
 
     def smart_merge(parent, child)

--- a/spec/overcommit/cli_spec.rb
+++ b/spec/overcommit/cli_spec.rb
@@ -23,6 +23,20 @@ describe Overcommit::CLI do
       end
     end
 
+    context 'with the --list-hooks option specified' do
+      let(:arguments) { ['--list-hooks'] }
+      let(:contexts) do
+        Overcommit::ConfigurationLoader.load_repo_config.all_hooks.keys
+      end
+
+      before { cli.stub(:halt) }
+
+      it 'prints the installed hooks' do
+        logger.should_receive(:log).at_least(:once)
+        subject
+      end
+    end
+
     context 'with the uninstall switch specified' do
       let(:arguments) { ['--uninstall'] }
 


### PR DESCRIPTION
This commit adds a command line option (-l/--list-hooks) to list all the
hooks available for a given repo. All hooks will be printed sorted by
the context in which they run, along with whether the hook is currently
enabled or disabled.

In order to do this I made `Overcommit::Configuration#hook_enabled?`
public. There is logic there to determine whether a certain hook is
enabled or disabled for a given context, and rather than duplicate this
logic elsewhere, it made more sense to make the method available to
`Overcommit::CLI` when printing the hooks.

Change-Id: Ief2bddf04957fb208c50f2faec4b705879825d89
