### PR TITLE
Fix Chamber integration

### DIFF
--- a/lib/overcommit/hook/pre_commit/chamber_security.rb
+++ b/lib/overcommit/hook/pre_commit/chamber_security.rb
@@ -2,7 +2,7 @@ module Overcommit::Hook::PreCommit
   # Runs `chamber secure` against any modified Chamber settings files
   class ChamberSecurity < Base
     def run
-      result = execute(%W[#{executable} secure --echo --files] + applicable_files)
+      result = execute(%W[#{executable} secure --files] + applicable_files)
 
       return :pass if result.stdout.empty?
       [:fail, "These settings appear to need to be secured but were not: #{result.stdout}"]


### PR DESCRIPTION
The way that Chamber outputs secure variables now does not require the `--echo` flag and therefore this can be removed.  This should now allow Chamber and Overcommit to play nicely together assuming the correct `includes` paths are set.

I'm going to fix the `includes` paths in a subsequent PR.
