### PR TITLE
Fix 'include' path for ChamberSecurity

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -82,7 +82,9 @@ PreCommit:
     description: 'Checking that settings have been secured with Chamber'
     required_executable: 'chamber'
     install_command: 'gem install chamber'
-    include: 'config/settings.yml'
+    include:
+      - 'config/settings.yml'
+      - 'config/settings/**/*.yml'
 
   CoffeeLint:
     description: 'Analyzing with coffeelint'


### PR DESCRIPTION
Chamber actually looks in two places by default for its settings files.  The first is `config/settings.yml`.  The second is any `.yml` file under the `config/settings` directory.  This change makes this the default so all one has to do is to set the `ChamberSecurity` plugin to `enabled`.
