### PR TITLE
Add --no-pngout flag for image_optim command on :fail message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Overcommit Changelog
 
+## master (unreleased)
+* Add `--no-pngout` flag for `image_optim` command on `:fail` message
+
 ## 0.18.0
 
 * Update minimum version of `image_optim` gem to 0.15.0 (breaking change in

--- a/lib/overcommit/hook/pre_commit/image_optim.rb
+++ b/lib/overcommit/hook/pre_commit/image_optim.rb
@@ -19,7 +19,7 @@ module Overcommit::Hook::PreCommit
         return :fail,
           "The following images are optimizable:\n#{optimized_images.join("\n")}" \
           "\n\nOptimize them by running:\n" \
-          "  image_optim #{optimized_images.join(' ')}"
+          "  image_optim --no-pngout #{optimized_images.join(' ')}"
       end
 
       :pass


### PR DESCRIPTION
Because `pngout` is skipped in `ImageOptim.new(:pngout => false)`, it should be skipped too or else it will fail silently when `pngout` is not installed.
