### PR TITLE
Pass comma separated list of files to brakeman

### DIFF
--- a/lib/overcommit/hook/pre_commit/brakeman.rb
+++ b/lib/overcommit/hook/pre_commit/brakeman.rb
@@ -2,8 +2,8 @@ module Overcommit::Hook::PreCommit
   # Runs `brakeman` against any modified Ruby/Rails files.
   class Brakeman < Base
     def run
-      result = execute(%W[#{executable} --exit-on-warn --quiet --summary --only-files] +
-                       applicable_files)
+      result = execute(%W[#{executable} --exit-on-warn --quiet --summary --only-files] <<
+                       applicable_files.join(','))
       return :pass if result.success?
 
       [:fail, result.stdout]


### PR DESCRIPTION
When a space separated list of files is passed to brakeman with the
--only-files option, brakeman fails with the error 'Please supply the
path to a Rails application.' When the files are passed as a comma
separated string, all is well.
