### PR TITLE
Correct extract line number output in Stylelint hook

### DIFF
--- a/lib/overcommit/hook/pre_commit/stylelint.rb
+++ b/lib/overcommit/hook/pre_commit/stylelint.rb
@@ -8,7 +8,7 @@ module Overcommit::Hook::PreCommit
     # example of output:
     # index.css: line 4, col 4, error - Expected indentation of 2 spaces (indentation)
 
-    MESSAGE_REGEX = /^(?<file>.+):\D*(?<line>\d).*$/
+    MESSAGE_REGEX = /^(?<file>.+):\D*(?<line>\d+).*$/
 
     def run
       result = execute(command, args: applicable_files)

--- a/spec/overcommit/hook/pre_commit/stylelint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/stylelint_spec.rb
@@ -40,7 +40,7 @@ describe Overcommit::Hook::PreCommit::Stylelint do
 
       it { should fail_hook }
 
-      it "extracts lines numbers correctly from output" do
+      it 'extracts lines numbers correctly from output' do
         expect(subject.run.map(&:line)).to eq([4, 10])
       end
     end

--- a/spec/overcommit/hook/pre_commit/stylelint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/stylelint_spec.rb
@@ -39,6 +39,10 @@ describe Overcommit::Hook::PreCommit::Stylelint do
       end
 
       it { should fail_hook }
+
+      it "extracts lines numbers correctly from output" do
+        expect(subject.run.map(&:line)).to eq([4, 10])
+      end
     end
   end
 end


### PR DESCRIPTION
The MESSAGE_REGEX for stylelint does not appropriately extract
line numbers >= 10.  This can cause the hook to incorrectly report
errors on modified lines as being for lines that are not modified.

This commit changes the regex to correctly handle multiple digits in
line numbers.

### Reproduction Steps

1. Create an empty git repository
2. Install overcommit with the following configuration in `.overcommit.yml` in the repository
    ```
    PreCommit:
      Stylelint:
        enabled: true
        command: "stylelint"
        problem_on_unmodified_line: "warn"
    ```
3. Install `stylelint` and create a `.stylelintrc.json` file in the repository:
    ```
    {
      "rules": {
        "declaration-block-trailing-semicolon": "always"
      }
    }
    ```
4. Create a file named `failing_file.scss` in the repository with the following content:
    ```
    .selector-1 { width: 20%; }
    .selector-2 { width: 20%; }
    .selector-3 { width: 20%; }
    .selector-4 { width: 20%; }
    .selector-5 { width: 20%; }
    .selector-6 { width: 20%; }
    .selector-7 { width: 20%; }
    .selector-8 { width: 20%; }
    .selector-9 { width: 20%; }
    .selector-10 { width: 20%; }
    .selector-11 { width: 20%; }
    ```
5. Commit these files.  Overcommit should pass.
6. Modify line 11 of `failing_file.scss` to be the following:
    ```
    .selector-11 { width: 20% }
    ```
7. Run `git commit -a`.  This should fail with an error on the modified line.  Instead, it passes with a warning on lines you did not modify:
    ```
    $ git commit -a
    Running pre-commit hooks
    Check styles with Stylelint...............................[Stylelint] WARNING
    Errors on lines you didn't modify:
    /Users/seckenrode/development/stylelint-test/failing_file.scss: line 11, col 25, error - Expected a trailing semicolon (declaration-block-trailing-semicolon)
    ```

After this change, the check fails with an error as expected.