### PR TITLE
Add more replace_branch config options

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1192,6 +1192,7 @@ PrepareCommitMsg:
     description: 'Prepends the commit message with text based on the branch name'
     branch_pattern: '\A.*\w+[-_](\d+).*\z'
     replacement_text: '[#\1]'
+    skipped_commit_types: ['message', 'template', 'merge', 'squash']
     on_fail: warn
 
 # Hooks that run during `git push`, after remote refs have been updated but

--- a/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
+++ b/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
@@ -45,7 +45,19 @@ describe Overcommit::Hook::PrepareCommitMsg::ReplaceBranch do
     context 'when the checked out branch does not match the pattern' do
       let(:new_head) { "this shouldn't match the default pattern" }
 
-      it { is_expected.to warn }
+      context 'when the commit type is in `skipped_commit_types`' do
+        let(:context) do
+          Overcommit::HookContext::PrepareCommitMsg.new(
+            config, [prepare_commit_message_file, 'template'], StringIO.new
+          )
+        end
+
+        it { is_expected.to pass }
+      end
+
+      context 'when the commit type is not in `skipped_commit_types`' do
+        it { is_expected.to warn }
+      end
     end
   end
 


### PR DESCRIPTION

Currently, [ReplaceBranch][1] only runs if the commit type is [commit][2],
which means the hook won't run if you are using a template, for
instance.

This commit enhances the replace_branch prepare commit message hook to
allow specifying the types of commits to not apply this hook to.

So now, I can run this hook during merges, and when using templates by excluding `template` and `merge` in the config

```
ReplaceBranch:
  enabled: true
  skipped_commit_types: ['message', 'squash']
```

[1]: https://github.com/sds/overcommit/blob/569dc24a64e4b839b247658a688deccb03b716b8/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb#L7
[2]: https://github.com/sds/overcommit/blob/569dc24a64e4b839b247658a688deccb03b716b8/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb#L10