### PR TITLE
[FEATURE] New pre-commit hook: RubySyntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ issue](https://github.com/sds/overcommit/issues/238) for more details.
 * [Reek](lib/overcommit/hook/pre_commit/reek.rb)
 * [RuboCop](lib/overcommit/hook/pre_commit/rubo_cop.rb)
 * [RubyLint](lib/overcommit/hook/pre_commit/ruby_lint.rb)
+* [RubySyntax](lib/overcommit/hook/pre_commit/ruby_syntax.rb)
 * [SwiftLint](lib/overcommit/hook/pre_commit/swift_lint.rb)
 * [Scalariform](lib/overcommit/hook/pre_commit/scalariform.rb)
 * [Scalastyle](lib/overcommit/hook/pre_commit/scalastyle.rb)

--- a/config/default.yml
+++ b/config/default.yml
@@ -678,7 +678,11 @@ PreCommit:
     enabled: false
     description: 'Check ruby syntax'
     required_executable: 'ruby'
-    command: ['bash', '-c', 'find . -name "*.rb" -exec ruby -c {} \; | grep -q "Syntax OK"']
+    command: [
+      'ruby',
+      '-e',
+      'ARGV.each { |applicable_file| ruby_c_output = `ruby -c #{applicable_file}`; puts ruby_c_output if ruby_c_output != "Syntax OK" }'
+    ]
     include:
       - '**/*.gemspec'
       - '**/*.rb'

--- a/config/default.yml
+++ b/config/default.yml
@@ -678,6 +678,7 @@ PreCommit:
     enabled: false
     description: 'Check ruby syntax'
     required_executable: 'ruby'
+    command: ['bash', '-c', 'find . -name "*.rb" -exec ruby -c {} \; | grep -q "Syntax OK"']
     include:
       - '**/*.gemspec'
       - '**/*.rb'

--- a/config/default.yml
+++ b/config/default.yml
@@ -674,6 +674,14 @@ PreCommit:
       - '**/*.gemspec'
       - '**/*.rb'
 
+  RubySyntax:
+    enabled: false
+    description: 'Check ruby syntax'
+    required_executable: 'ruby'
+    include:
+      - '**/*.gemspec'
+      - '**/*.rb'
+
   Scalariform:
     enabled: false
     description: 'Check formatting with Scalariform'

--- a/config/default.yml
+++ b/config/default.yml
@@ -681,7 +681,7 @@ PreCommit:
     command: [
       'ruby',
       '-e',
-      'ARGV.each { |applicable_file| ruby_c_output = `ruby -c #{applicable_file}`; puts ruby_c_output if ruby_c_output != "Syntax OK" }'
+      'ARGV.each { |applicable_file| ruby_c_output = `ruby -c #{applicable_file}`; puts ruby_c_output unless $?.success? }'
     ]
     include:
       - '**/*.gemspec'

--- a/lib/overcommit/hook/pre_commit/ruby_syntax.rb
+++ b/lib/overcommit/hook/pre_commit/ruby_syntax.rb
@@ -9,8 +9,7 @@ module Overcommit::Hook::PreCommit
     end
 
     def run
-      cmd = ['bash', '-c', 'find . -name "*.rb" -exec ruby -c {} \; | grep -q "Syntax OK"']
-      result = execute(cmd, args: applicable_files)
+      result = execute(command, args: applicable_files)
 
       result_lines = result.stderr.split("\n")
 

--- a/spec/overcommit/hook/pre_commit/ruby_syntax_spec.rb
+++ b/spec/overcommit/hook/pre_commit/ruby_syntax_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::RubySyntax do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.rb file2.rb])
+  end
+
+  context 'when ruby_syntax exits successfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'with no errors' do
+      before do
+        result.stub(:stderr).and_return('')
+      end
+
+      it { should pass }
+    end
+  end
+
+  context 'when ruby_syntax exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stderr).and_return([
+                                          "file1.rb:2: syntax error, unexpected '^'"
+                                        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Pre-commit hook RubySyntax check ruby files for syntax errors and show where the errors are.

It uses ruby -c to check syntax.

Useful if some files are not loaded automatically when performing the tests.