### PR TITLE
Relax childprocess dependency version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'coveralls', '~> 0.8'
 
 # Pin RuboCop for Travis builds.
 gem 'rubocop', '0.54.0'
+
+gem 'ffi' if Gem.win_platform?

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency          'childprocess', '~> 0.6', '>= 0.6.3'
+  s.add_dependency          'childprocess', '>= 0.6.3', '< 2.0'
   s.add_dependency          'iniparse', '~> 1.4'
 end


### PR DESCRIPTION
`childprocess` turned `1` on January, so I tried to relax `childprocess` dependency version from `~> 0.6` to `>= 0.6.3`.

Let's see if CI passes :)