### PR TITLE
Relax childprocess dependency version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem 'coveralls', '~> 0.8'
 
 # Pin RuboCop for Travis builds.
 gem 'rubocop', '0.54.0'
+
+gem 'ffi' if Gem.win_platform?

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ This project aims to support the following Ruby runtimes on both \*nix and Windo
 
 * Ruby 2.4+
 
+### Windows
+
+If you are using Overcommit on **Windows**, make sure you include the `ffi` gem in your
+list of dependencies. Overcommit does not include the `ffi` gem by default since it
+significantly increases the install time for non-Windows platforms.
+
 ### Dependencies
 
 Some of the hooks have third-party dependencies. For example, to lint your

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency          'childprocess', '~> 0.6', '>= 0.6.3'
+  s.add_dependency          'childprocess', '>= 0.6.3', '< 2.0'
   s.add_dependency          'iniparse', '~> 1.4'
 end

--- a/spec/integration/gemfile_option_spec.rb
+++ b/spec/integration/gemfile_option_spec.rb
@@ -13,6 +13,7 @@ describe 'specifying `gemfile` option in Overcommit configuration' do
 
     gem 'overcommit', path: '#{repo_root}'
     gem 'my_fake_gem', path: '#{fake_gem_path}'
+    gem 'ffi' if Gem.win_platform? # Necessary for test to pass on Windows
   RUBY
 
   let(:gemspec) { normalize_indent(<<-RUBY) }


### PR DESCRIPTION
ChildProcess no longer includes `ffi` by default (see https://github.com/enkessler/childprocess/issues/150 for context). Ensure we include the gem on Windows builds and update the documentation appropriately.

Based on #649