### PR TITLE
Bug/650 traceback when setting parallelize to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `skipped_commit_types` option to `ReplaceBranch` prepare-commit-msg hook
 * Add `RubySyntax` pre-commit hook
 * Relax `childprocess` dependency to allow version 1.x
+* Fix deadlock which was more likely to occur when setting `parallelize` on a hook to `false`
 
 ## 0.48.1
 

--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -129,12 +129,9 @@ module Overcommit
         slots_released = processors_for_hook(hook)
         @slots_available += slots_released
 
-        if @hooks_left.any?
-          # Signal once. `wait_for_slot` will perform additional signals if
-          # there are still slots available. This prevents us from sending out
-          # useless signals
-          @resource.signal
-        end
+        # Signal every time in case there are threads that are already waiting for
+        # these slots to be released
+        @resource.signal
       end
     end
 

--- a/spec/integration/parallelize_spec.rb
+++ b/spec/integration/parallelize_spec.rb
@@ -7,10 +7,16 @@ describe 'running a hook with parallelism disabled' do
   subject { shell(%w[git commit --allow-empty -m Test]) }
 
   let(:config) { <<-YML }
+    concurrency: 20
     CommitMsg:
       TrailingPeriod:
         enabled: true
         parallelize: false
+        command: ['ruby', '-e', 'sleep 1']
+      TextWidth:
+        enabled: true
+        parallelize: true
+        processors: 1
   YML
 
   around do |example|
@@ -22,6 +28,7 @@ describe 'running a hook with parallelism disabled' do
   end
 
   it 'does not hang' do
-    Timeout.timeout(5) { subject }
+    result = Timeout.timeout(5) { subject }
+    result.stderr.should_not include 'No live threads left. Deadlock?'
   end
 end


### PR DESCRIPTION
If parallelize is false then a hook will consume all the slots. Other threads may be processing other hooks but will wait for the slots to be released. Therefore a signal must be sent whenever slots are released.

Fixes #650