### PR TITLE
Fix typo: `require_executable` -> `required_executable`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -759,7 +759,7 @@ PreCommit:
   Stylelint:
     enabled: false
     description: 'Check styles with Stylelint'
-    require_executable: 'stylelint'
+    required_executable: 'stylelint'
     flags: ['-f', 'compact']
     install_command: 'npm install -g stylelint'
     include:


### PR DESCRIPTION
It looks like this incorrect field name has existed since the inception
of the Stylelint plugin in
https://github.com/sds/overcommit/commit/22229c95854cdd02d19e6e24e20d7df9ac23fea3.