### PR TITLE
Get rid of the redundant Limitations item in TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ any Ruby code.
 
 * [Requirements](#requirements)
   * [Dependencies](#dependencies)
-* [Limitations](#limitations)
 * [Installation](#installation)
   * [Automatically Install Overcommit Hooks](#automatically-install-overcommit-hooks)
 * [Usage](#usage)


### PR DESCRIPTION
The Limitations section was removed here https://github.com/sds/overcommit/commit/10c208081c9f5ff6adf479e7cbce44ad130cb514#diff-04c6e90faac2675aa89e2176d2eec7d8