### PR TITLE
Add C to rubocop warnings

### DIFF
--- a/lib/overcommit/hook/pre_commit/rubo_cop.rb
+++ b/lib/overcommit/hook/pre_commit/rubo_cop.rb
@@ -10,7 +10,7 @@ module Overcommit::Hook::PreCommit
     end
 
     COP_MESSAGE_TYPE_CATEGORIZER = lambda do |type|
-      type.include?('W') ? :warning : :error
+      (type.include?('W') || type.include?('C')) ? :warning : :error 
     end
 
     def run


### PR DESCRIPTION
C is for convention. it should be a warning instead of an error. 

This PR fixes it