### PR TITLE
Disable literal pathspecs when applying stash

### DIFF
--- a/lib/overcommit/hook_context/pre_commit.rb
+++ b/lib/overcommit/hook_context/pre_commit.rb
@@ -53,9 +53,11 @@ module Overcommit::HookContext
         @stash_attempted = true
 
         stash_message = "Overcommit: Stash of repo state before hook run at #{Time.now}"
-        result = Overcommit::Utils.execute(
-          %w[git -c commit.gpgsign=false stash save --keep-index --quiet] + [stash_message]
-        )
+        result = Overcommit::Utils.with_environment('GIT_LITERAL_PATHSPECS' => '0') do
+          Overcommit::Utils.execute(
+            %w[git -c commit.gpgsign=false stash save --keep-index --quiet] + [stash_message]
+          )
+        end
 
         unless result.success?
           # Failure to stash in this case is likely due to a configuration


### PR DESCRIPTION
We need this in order to work around the behavior of emacs/magit where
it sets GIT_LITERAL_PATHSPECS=1, causing errors like:

    Unable to setup environment for pre-commit hook run:
    STDOUT:
    STDERR:error: pathspec ':/' did not match any file(s) known to git

Overriding the environment variable solves this issue.

Fixes #671.