### PR TITLE
Do not specify minor ruby version for rvm in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4
+  - 2.5
+  - 2.6
 
 before_script:
   - git config --global user.email "travis@travis.ci"


### PR DESCRIPTION
This helps not to perform commit like this:
https://github.com/sds/overcommit/commit/2ccd9bd7d86e369135c698ad9c8f9274d8b1570b

or

https://github.com/sds/overcommit/commit/ef8eb44153ac54ac3a3cebaad4fc09e5a78cf9fa