### PR TITLE
Avoid stashing changes when all changes are staged

### DIFF
--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -158,6 +158,25 @@ describe Overcommit::HookContext::PreCommit do
       end
     end
 
+    context 'when all changes have been staged' do
+      around do |example|
+        repo do
+          echo('Hello World', 'tracked-file')
+          `git add tracked-file`
+          `git commit -m "Add tracked-file"`
+          echo('Hello Other World', 'other-tracked-file')
+          `git add other-tracked-file`
+          example.run
+        end
+      end
+
+      it 'does not stash changes' do
+        expect(context.private_methods).to include :stash_changes
+        expect(context).not_to receive(:stash_changes)
+        subject
+      end
+    end
+
     context 'when renaming a file during an amendment' do
       around do |example|
         repo do
@@ -316,6 +335,27 @@ describe Overcommit::HookContext::PreCommit do
             File.mtime('untracked-file')
           ]
         }
+      end
+    end
+
+    context 'when all changes were staged' do
+      around do |example|
+        repo do
+          echo('Hello World', 'tracked-file')
+          `git add tracked-file`
+          `git commit -m "Add tracked-file"`
+          echo('Hello Other World', 'other-tracked-file')
+          `git add other-tracked-file`
+          example.run
+        end
+      end
+
+      it 'does not touch the working tree' do
+        expect(context.private_methods).to include :clear_working_tree
+        expect(context.private_methods).to include :restore_working_tree
+        expect(context).not_to receive(:clear_working_tree)
+        expect(context).not_to receive(:restore_working_tree)
+        subject
       end
     end
 


### PR DESCRIPTION
It was suggested in #135 that a potential way to avoid unnecessary file change detection and general stashing woes would be to stash changes only when there were unstaged changes that needed to be excluded from the run.

This presents a nice optimization that I wish we had considered long ago. We can simplify the logic now that we see the purpose of this feature a little more clearly: stash only when you need to.

Issue #669 raised an interesting point about the difficulty to detect if a stash entry was created, so we modified the tests to check if a method call was made to validate the logic. This isn't great as it's peeking deep into the implementation, so we added some additional tests that ensured the methods in question actually existed. Not perfect, but gives us some confidence in the implementation.

While here, we were able to:

* Extract the stashing logic into a separate `stash_changes` helper method.

* Simplify the `cleanup_environment` logic to just use whether changes were stashed in order to decide whether to restore.

Closes #669.