### PR TITLE
Remove CRLF warnings from AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ before_test:
   - git config --global user.name "Appveyor CI"
 
   # Ignore CRLF conversion warnings
+  - git config --global core.autocrlf true
   - git config --global core.safecrlf false
 
 test_script:


### PR DESCRIPTION
We get a lot of these warnings in our Windows tests.

    warning: CRLF will be replaced by LF in <file name>.
    The file will have its original line endings in your working directory.

Remove by adding this setting.