### PR TITLE
Provide better instructions on commit-msg failure

### DIFF
--- a/lib/overcommit/hook_context/commit_msg.rb
+++ b/lib/overcommit/hook_context/commit_msg.rb
@@ -34,7 +34,9 @@ module Overcommit::HookContext
     end
 
     def post_fail_message
-      "Failed commit message:\n" + commit_message_lines.join
+      "Failed commit message:\n#{commit_message_lines.join.chomp}\n\n" \
+      "Try again with your existing commit message by running:\n" \
+      "git commit --edit --file=#{commit_message_file}"
     end
 
     private

--- a/spec/overcommit/hook_context/commit_msg_spec.rb
+++ b/spec/overcommit/hook_context/commit_msg_spec.rb
@@ -92,7 +92,11 @@ describe Overcommit::HookContext::CommitMsg do
     subject { context.post_fail_message }
 
     it 'returns printable log of commit message' do
-      subject.should == "Failed commit message:\nSome commit message\n"
+      subject.should start_with "Failed commit message:\nSome commit message\n"
+    end
+
+    it 'returns the command to run to restore the commit message' do
+      subject.should end_with "git commit --edit --file=#{commit_message_file}"
     end
   end
 end


### PR DESCRIPTION
Extend the technique introduced in #519 to instead provide clear instructions on how to re-attempt your commit message starting from the one you previously had.

This is instructional to users who aren't familiar with this feature of Git.

Now commit-msg failures will be followed up with:

    Try again with your existing commit message by running:
    git commit --edit --file=.git/COMMIT_EDITMSG

The reason we don't attempt to simply re-open the editor is that by the time we've failed the hook, Git has already decided the run has failed and there is no means of recovery.

Closes #651.