### PR TITLE
Introduce `exclude_branch_patterns` on Hook Config

### DIFF
--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -79,12 +79,17 @@ module Overcommit::Hook
       @config['enabled'] != false
     end
 
+    def excluded?
+      exclude_branch_patterns.any? { |p| File.fnmatch(p, current_branch) }
+    end
+
     def skip?
       @config['skip']
     end
 
     def run?
       enabled? &&
+      !excluded? &&
         !(@config['requires_files'] && applicable_files.empty?)
     end
 
@@ -275,6 +280,14 @@ module Overcommit::Hook
       else
         status
       end
+    end
+
+    def exclude_branch_patterns
+      @config['exclude_branch_patterns'] || []
+    end
+
+    def current_branch
+      @current_branch ||= Overcommit::GitRepo.current_branch
     end
   end
 end

--- a/spec/overcommit/hook/base_spec.rb
+++ b/spec/overcommit/hook/base_spec.rb
@@ -34,4 +34,92 @@ describe Overcommit::Hook::Base do
       end
     end
   end
+
+  describe '#run?' do
+    let(:modified_files) { [] }
+    let(:hook_config) do
+      {
+        'enabled' => enabled,
+        'requires_files' => requires_files,
+      }
+    end
+
+    before do
+      config.stub(:for_hook).and_return(hook_config)
+      context.stub(:modified_files).and_return(modified_files)
+    end
+
+    subject { hook.run? }
+
+    context 'enabled is true, requires_files is false, modified_files empty' do
+      let(:enabled) { true }
+      let(:requires_files) { false }
+
+      it { subject.should == true }
+    end
+
+    context 'enabled is false, requires_files is false, modified_files empty' do
+      let(:enabled) { false }
+      let(:requires_files) { false }
+
+      it { subject.should == false }
+    end
+
+    context 'enabled is true, requires_files is true, modified_files is not empty' do
+      let(:enabled) { true }
+      let(:requires_files) { true }
+      let(:modified_files) { ['file1'] }
+
+      it { subject.should == true }
+    end
+
+    context 'enabled is true, requires_files is false, modified_files is not empty' do
+      let(:enabled) { true }
+      let(:requires_files) { false }
+      let(:modified_files) { ['file1'] }
+
+      it { subject.should == true }
+    end
+
+    context 'with exclude_branch_patterns' do
+      let(:current_branch) { 'tj-test-branch' }
+      let(:hook_config) do
+        {
+          'enabled' => true,
+          'requires_files' => false,
+          'exclude_branch_patterns' => exclude_branch_patterns
+        }
+      end
+
+      before do
+        allow(Overcommit::GitRepo).
+          to receive(:current_branch).
+          and_return(current_branch)
+      end
+
+      context 'exclude_branch_patterns is nil' do
+        let(:exclude_branch_patterns) { nil }
+
+        it { subject.should == true }
+      end
+
+      context 'exact match between exclude_branch_patterns and current_branch' do
+        let(:exclude_branch_patterns) { ['tj-test-branch'] }
+
+        it { subject.should == false }
+      end
+
+      context 'partial match between exclude_branch_patterns and current_branch' do
+        let(:exclude_branch_patterns) { ['tj-test-*'] }
+
+        it { subject.should == false }
+      end
+
+      context 'non-match between exclude_branch_patterns and current_branch' do
+        let(:exclude_branch_patterns) { ['test-*'] }
+
+        it { subject.should == true }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Context
=
This will allow user to skip any Hook based on branch patterns.

For example, if the user wish to skip a particular Hook (i.e. Rubocop) for `staging` branch,
the user could specify below

```
PreCommit:
  Rubocop:
   exclude_branch_patterns: ['staging']
```
or using glob partial pattern

```
PreCommit:
  Rubocop:
   exclude_branch_patterns: ['stag*']
```

By default `exclude_branch_patterns` is empty (includes all branches).