### PR TITLE
Introduce "exclude_remote_names" to Skip Hook During PrePush Based on Remote Name

### DIFF
--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -286,6 +286,10 @@ module Overcommit::Hook
       @config['exclude_branch_patterns'] || []
     end
 
+    def exclude_remote_names
+      @config['exclude_remote_names'] || []
+    end
+
     def current_branch
       @current_branch ||= Overcommit::GitRepo.current_branch
     end

--- a/lib/overcommit/hook/pre_push/base.rb
+++ b/lib/overcommit/hook/pre_push/base.rb
@@ -8,5 +8,9 @@ module Overcommit::Hook::PrePush
     extend Forwardable
 
     def_delegators :@context, :remote_name, :remote_url, :pushed_refs
+
+    def skip?
+      super || exclude_remote_names.include?(remote_name)
+    end
   end
 end

--- a/spec/overcommit/hook/pre_push/base_spec.rb
+++ b/spec/overcommit/hook/pre_push/base_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Overcommit::Hook::PrePush::Base do
+  let(:remote_name) { 'origin' }
+  let(:config) { double('config') }
+  let(:context) { double('context') }
+  let(:hook) { described_class.new(config, context) }
+  describe '#run?' do
+    let(:hook_config) do
+      { 'skip' => skip }
+    end
+
+    before do
+      allow(context).to receive(:remote_name).and_return(remote_name)
+      allow(config).to receive(:for_hook).and_return(hook_config)
+    end
+
+    subject { hook.skip? }
+
+    context 'skip is true' do
+      let(:skip) { true }
+
+      it { subject.should == true }
+    end
+
+    context 'skip is false' do
+      let(:skip) { false }
+
+      it { subject.should == false }
+    end
+
+    context 'with exclude_remote_names specified' do
+      let(:hook_config) do
+        { 'skip' => skip, 'exclude_remote_names' => exclude_remote_names }
+      end
+      let(:exclude_remote_names) { nil }
+
+      context 'skip is true and exclude_remote_names is nil' do
+        let(:skip) { true }
+        let(:exclude_remote_names) { nil }
+
+        it { subject.should == true }
+      end
+
+      context 'skip is false and exclude_remote_names is nil' do
+        let(:skip) { false }
+        let(:exclude_remote_names) { nil }
+
+        it { subject.should == false }
+      end
+
+      context 'skip is true and matching exclude_remote_names is nil' do
+        let(:skip) { true }
+        let(:exclude_remote_names) { ['origin'] }
+
+        it { subject.should == true }
+      end
+
+      context 'skip is false and matching exclude_remote_names is nil' do
+        let(:skip) { false }
+        let(:exclude_remote_names) { ['origin'] }
+
+        it { subject.should == true }
+      end
+
+      context 'skip is true and non-matching exclude_remote_names is nil' do
+        let(:skip) { true }
+        let(:exclude_remote_names) { ['heroku'] }
+
+        it { subject.should == true }
+      end
+
+      context 'skip is false and non-matching exclude_remote_names is nil' do
+        let(:skip) { false }
+        let(:exclude_remote_names) { ['heroku'] }
+
+        it { subject.should == false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Context
=
Allow user to skip certain Hooks when pushing changes to certain remote repository.

For example, user could a Hook (i.e. RSpec), when pushing to 'heroku' remote name.
```
PrePush:
  RSpec:
    exclude_remote_names: ['heroku']
```

This is an attempt to solve issue reported in https://github.com/sds/overcommit/issues/588