### PR TITLE
[PrePush::ProtectedBranches] Implement setting destructive_only per branch

### DIFF
--- a/lib/overcommit/hook/pre_push/protected_branches.rb
+++ b/lib/overcommit/hook/pre_push/protected_branches.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Overcommit::Hook::PrePush
-  # Prevents destructive updates to specified branches.
+  # Prevents updates to specified branches.
+  # Accepts a 'destructive_only' option globally or per branch
+  # to only prevent destructive updates.
   class ProtectedBranches < Base
     def run
       return :pass unless illegal_pushes.any?
@@ -17,32 +19,55 @@ module Overcommit::Hook::PrePush
 
     def illegal_pushes
       @illegal_pushes ||= pushed_refs.select do |pushed_ref|
-        protected?(pushed_ref.remote_ref) && allow_non_destructive?(pushed_ref)
+        protected?(pushed_ref)
       end
     end
 
-    def protected?(remote_ref)
+    def protected?(ref)
+      find_pattern(ref.remote_ref)&.destructive?(ref)
+    end
+
+    def find_pattern(remote_ref)
       ref_name = remote_ref[%r{refs/heads/(.*)}, 1]
-      return false if ref_name.nil?
-      protected_branch_patterns.any? do |pattern|
-        File.fnmatch(pattern, ref_name)
+      return if ref_name.nil?
+
+      patterns.find do |pattern|
+        File.fnmatch(pattern.to_s, ref_name)
       end
     end
 
-    def protected_branch_patterns
-      @protected_branch_patterns ||= Array(config['branches']).
-        concat(Array(config['branch_patterns']))
+    def patterns
+      @patterns ||= fetch_patterns
     end
 
-    def destructive_only?
+    def fetch_patterns
+      branch_configurations.map do |pattern|
+        if pattern.is_a?(Hash)
+          Pattern.new(pattern.keys.first, pattern['destructive_only'])
+        else
+          Pattern.new(pattern, global_destructive_only?)
+        end
+      end
+    end
+
+    def branch_configurations
+      config['branches'].to_a + config['branch_patterns'].to_a
+    end
+
+    def global_destructive_only?
       config['destructive_only'].nil? || config['destructive_only']
     end
 
-    def allow_non_destructive?(ref)
-      if destructive_only?
-        ref.destructive?
-      else
-        true
+    Pattern = Struct.new('Pattern', :name, :destructive_only) do
+      alias_method :to_s, :name
+      alias_method :destructive_only?, :destructive_only
+
+      def destructive?(ref)
+        if destructive_only?
+          ref.destructive?
+        else
+          true
+        end
       end
     end
   end

--- a/spec/integration/protected_branches_spec.rb
+++ b/spec/integration/protected_branches_spec.rb
@@ -24,6 +24,8 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
         enabled: true
         branches:
           - protected
+          - protected_for_destructive_only:
+            destructive_only: true
   YML
 
   around do |example|


### PR DESCRIPTION
`PrePush::ProtectedBranches` supports a `destructive_only` setting. However, this setting is globally valid for all protected branches. It makes sense to set this setting on a per branch basis. This PR implements the following syntax for the configuration of `ProtectedBranches`.

```yaml
PrePush:
  ProtectedBranches:
    enabled: true
    branches:
      - protected
      - protected_for_destructive_only:
         destructive_only: true
```

In case it is not set on a branch it will fall back to the global setting. Additionally it will use the setting of the first matching branch. 

Example:
```yaml
PrePush:
  ProtectedBranches:
    enabled: true
    branch_patterns:
      - releases/*
      - releases/v1:
         destructive_only: true
```

In this case, a push to `releases/v1` would be forbidden because `releases/*` would match which uses the global setting for `destructive_only`. The solution in this case would be to flip the order of the branch definitions.

Credit for this idea goes to @davidstosik 🎉 