### PR TITLE
Add test cases for Destructive only per branch feature

### DIFF
--- a/spec/integration/protected_branches_spec.rb
+++ b/spec/integration/protected_branches_spec.rb
@@ -157,10 +157,6 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
   context 'when pushing to a protected branch' do
     let(:remote_ref) { 'protected' }
 
-    subject do
-      shell("git push #{flags} origin HEAD".split)
-    end
-
     context 'when pushing' do
       context 'with ProtectedBranches enabled' do
         include_context 'ProtectedBranches enabled'

--- a/spec/integration/protected_branches_spec.rb
+++ b/spec/integration/protected_branches_spec.rb
@@ -24,6 +24,8 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
         enabled: true
         branches:
           - protected_for_destructive_only
+          - protected:
+            destructive_only: false
 
   YML
 
@@ -31,6 +33,7 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
     remote_repo = repo do
       `git checkout -b protected_for_destructive_only > #{File::NULL} 2>&1`
       `git commit --allow-empty -m "Remote commit"`
+      `git checkout -b protected > #{File::NULL} 2>&1`
       `git checkout -b unprotected > #{File::NULL} 2>&1`
       `git checkout -b dummy > #{File::NULL} 2>&1`
     end
@@ -148,6 +151,21 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
 
     context 'when remote does not exist locally' do
       include_examples 'push succeeds'
+    end
+  end
+
+  context "when pushing to a protected branch" do
+    let(:remote_ref) { 'protected' }
+
+    subject do
+      shell("git push #{flags} origin HEAD".split)
+    end
+
+    context 'when pushing' do
+      context 'with ProtectedBranches enabled' do
+        include_context 'ProtectedBranches enabled'
+        include_examples 'push fails'
+      end
     end
   end
 

--- a/spec/integration/protected_branches_spec.rb
+++ b/spec/integration/protected_branches_spec.rb
@@ -23,14 +23,13 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
       ProtectedBranches:
         enabled: true
         branches:
-          - protected
-          - protected_for_destructive_only:
-            destructive_only: true
+          - protected_for_destructive_only
+
   YML
 
   around do |example|
     remote_repo = repo do
-      `git checkout -b protected > #{File::NULL} 2>&1`
+      `git checkout -b protected_for_destructive_only > #{File::NULL} 2>&1`
       `git commit --allow-empty -m "Remote commit"`
       `git checkout -b unprotected > #{File::NULL} 2>&1`
       `git checkout -b dummy > #{File::NULL} 2>&1`
@@ -152,8 +151,8 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
     end
   end
 
-  context 'when pushing to a protected branch' do
-    let(:remote_ref) { 'protected' }
+  context 'when pushing to a protected for destructive only branch' do
+    let(:remote_ref) { 'protected_for_destructive_only' }
 
     context 'when force-pushing' do
       include_context 'force-pushing'

--- a/spec/integration/protected_branches_spec.rb
+++ b/spec/integration/protected_branches_spec.rb
@@ -154,7 +154,7 @@ describe Overcommit::Hook::PrePush::ProtectedBranches,
     end
   end
 
-  context "when pushing to a protected branch" do
+  context 'when pushing to a protected branch' do
     let(:remote_ref) { 'protected' }
 
     subject do


### PR DESCRIPTION
**Background**
...



Destructive only per branch feature was introduced #692, by default all branches added to the ProtectedBranches the library consider to run this hook only when a push destructive only is performed. 