### PR TITLE
Live output option for rspec command

### DIFF
--- a/lib/overcommit/hook/pre_push/r_spec.rb
+++ b/lib/overcommit/hook/pre_push/r_spec.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PrePush
   # @see http://rspec.info/
   class RSpec < Base
     def run
-      result = execute(command)
+      result = execute(command, live_output: config['live_output'])
       return :pass if result.success?
 
       output = result.stdout + result.stderr

--- a/spec/overcommit/hook/pre_push/r_spec_spec.rb
+++ b/spec/overcommit/hook/pre_push/r_spec_spec.rb
@@ -77,4 +77,47 @@ describe Overcommit::Hook::PrePush::RSpec do
       it { should fail_hook }
     end
   end
+
+  context 'when live_output option is true' do
+    let(:config) do
+      Overcommit::ConfigurationLoader.default_configuration.merge(
+        Overcommit::Configuration.new(
+          'PrePush' => {
+            'RSpec' => {
+              'live_output' => true
+            }
+          }
+        )
+      )
+    end
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(true)
+    end
+
+    it 'calls execute with the live_output flag set' do
+      expect(subject).to receive(:execute).with(['rspec'], live_output: true).and_return(result)
+      expect(subject).to pass
+    end
+
+    context do
+      let(:child_process) { double('child process') }
+      let(:io) { double('io') }
+
+      it 'the child process inherits the io' do
+        io.stub(:inherit!)
+        child_process.stub(io: io, start: nil, wait: nil, exit_code: 0)
+        expect(ChildProcess).to receive(:build).with('rspec').and_return(child_process)
+        expect(subject).to pass
+      end
+
+      it 'the child process inherits the io' do
+        io.stub(:inherit!)
+        child_process.stub(io: io, start: nil, wait: nil, exit_code: 1)
+        expect(ChildProcess).to receive(:build).with('rspec').and_return(child_process)
+        expect(subject).to fail_hook
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Add new option live_output
* If passed, show output in real time, instead of waiting for the command to finish

fixes https://github.com/sds/overcommit/issues/583