### PR TITLE
Fix `YamlLint` hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Overcommit Changelog
 
+## master
+
+* Fix `YamlLint` pre-commit hook
+
 ## 0.53.0
 
 * Improve performance in `PhpCs` pre-commit hook

--- a/config/default.yml
+++ b/config/default.yml
@@ -885,7 +885,7 @@ PreCommit:
     enabled: false
     description: 'Analyze with YAMLlint'
     required_executable: 'yamllint'
-    flags: ['--format=parsable']
+    flags: ['--format=parsable', '--strict']
     install_command: 'pip install yamllint'
     include:
       - '**/*.yaml'

--- a/spec/overcommit/hook/pre_commit/yaml_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/yaml_lint_spec.rb
@@ -19,7 +19,7 @@ describe Overcommit::Hook::PreCommit::YamlLint do
   end
 
   before do
-    subject.stub(:execute).with(%w[yamllint --format=parsable], args: applicable_files).
+    subject.stub(:execute).with(%w[yamllint --format=parsable --strict], args: applicable_files).
       and_return(result)
   end
 


### PR DESCRIPTION
Previously, when yamllint was failing, the exit code of the tool was
reflecting that. However, recently yamllint introduced `--strict`
parameter to do that. Without, it always returns success no matter if
lints were successful or failed. Which caused false-positives in
ovecommit, which was thinking that everything is okay.

This fix adds `--strict` to `yamllint` invocation, to bring back proper
behavior, and force hook to fail, when the tool fails.