### PR TITLE
[authorname] allow for non-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Fix `Overcommit::GitRepo.list_files` helper to work with arbitrarily large lists of files.
+* `AuthorName` allows for non-0 length to be more inclusive of names.
 
 ## 0.54.0
 

--- a/lib/overcommit/hook/pre_commit/author_name.rb
+++ b/lib/overcommit/hook/pre_commit/author_name.rb
@@ -12,9 +12,9 @@ module Overcommit::Hook::PreCommit
           result.stdout.chomp
         end
 
-      unless name.split(' ').count >= 2
+      if name.empty?
         return :fail,
-               "Author must have at least first and last name, but was: #{name}.\n" \
+               "Author name must be non-0 in length.\n" \
                'Set your name with `git config --global user.name "Your Name"` ' \
                'or via the GIT_AUTHOR_NAME environment variable'
       end

--- a/spec/integration/committing_spec.rb
+++ b/spec/integration/committing_spec.rb
@@ -26,11 +26,21 @@ describe 'commiting' do
 
   context 'when a hook fails' do
     before do
-      `git config --local user.name "John"`
+      `git config --local user.name ""`
     end
 
     it 'exits with a non-zero status' do
       subject.status.should_not == 0
+    end
+  end
+
+  context 'when no hooks fail on single author name' do
+    before do
+      `git config --local user.name "John"`
+    end
+
+    it 'exits successfully' do
+      subject.status.should == 0
     end
   end
 

--- a/spec/overcommit/hook/pre_commit/author_name_spec.rb
+++ b/spec/overcommit/hook/pre_commit/author_name_spec.rb
@@ -18,7 +18,7 @@ describe Overcommit::Hook::PreCommit::AuthorName do
     context 'when user has only a first name' do
       let(:name) { 'John' }
 
-      it { should fail_hook }
+      it { should pass }
     end
 
     context 'when user has first and last name' do


### PR DESCRIPTION
* Updates the `AuthorName` check to be a little more inclusive by not requiring a first and last name.
* Could also leave this as-is and have a 2-strings type of check (maybe called `AuthorNameTwoStrings`) or something to represent this default setting?  Happy to do that if preferred.