### PR TITLE
Make #initial_commit? public

### DIFF
--- a/lib/overcommit/hook_context/helpers/stash_unstaged_changes.rb
+++ b/lib/overcommit/hook_context/helpers/stash_unstaged_changes.rb
@@ -23,6 +23,12 @@ module Overcommit::HookContext
         end
       end
 
+      # Returns whether the current git branch is empty (has no commits).
+      def initial_commit?
+        return @initial_commit unless @initial_commit.nil?
+        @initial_commit = Overcommit::GitRepo.initial_commit?
+      end
+
       # Restore unstaged changes and reset file modification times so it appears
       # as if nothing ever changed.
       #
@@ -59,12 +65,6 @@ module Overcommit::HookContext
           next unless File.exist?(file) # Ignore renamed files (old file no longer exists)
           @modified_times[file] = File.mtime(file)
         end
-      end
-
-      # Returns whether the current git branch is empty (has no commits).
-      def initial_commit?
-        return @initial_commit unless @initial_commit.nil?
-        @initial_commit = Overcommit::GitRepo.initial_commit?
       end
 
       # Returns whether there are any changes to tracked files which have not yet


### PR DESCRIPTION
I'll go with the smallest minimal change. We can always extract this to a module later on.

Closes #728