### PR TITLE
Delegate `modified_lines_in_file` to context

### DIFF
--- a/lib/overcommit/hook/commit_msg/base.rb
+++ b/lib/overcommit/hook/commit_msg/base.rb
@@ -9,6 +9,6 @@ module Overcommit::Hook::CommitMsg
 
     def_delegators :@context, :empty_message?, :commit_message,
                    :update_commit_message, :commit_message_lines,
-                   :commit_message_file
+                   :commit_message_file, :modified_lines_in_file
   end
 end


### PR DESCRIPTION
@sds This went under the radar since `modified_files` is delegated via `Overcommit::Hook::Base`.

Now that I tried writing a custom hook I noticed `modified_lines_in_file` is not available inside `Overcommit::Hook::CommitMsg::Base`. I decided to expose only the method I need but I think it's worth thinking about if we want to delegate all methods that come from included modules by default