### PR TITLE
Revise index-tags script

### DIFF
--- a/libexec/index-tags
+++ b/libexec/index-tags
@@ -6,10 +6,12 @@
 
 set -e
 
-trap "rm -f $GIT_DIR/tags.$$" EXIT
-err_file=$GIT_DIR/ctags.err
-if ctags --tag-relative -Rf$GIT_DIR/tags.$$ --exclude=.git "$@" 2>${err_file}; then
-  mv $GIT_DIR/tags.$$ $GIT_DIR/tags
+dir="`git rev-parse --git-dir`"
+
+trap "rm -f $dir/tags.$$" EXIT
+err_file=$dir/ctags.err
+if git ls-files | ctags --tag-relative -L - -f "$dir/tags.$$" 2>${err_file}; then
+  mv $dir/tags.$$ $dir/tags
   [ -e ${err_file} ] && rm -f ${err_file}
 else
   # Ignore STDERR unless `ctags` returned a non-zero exit code

--- a/libexec/index-tags
+++ b/libexec/index-tags
@@ -10,7 +10,7 @@ dir="`git rev-parse --git-dir`"
 
 trap "rm -f $dir/tags.$$" EXIT
 err_file=$dir/ctags.err
-if git ls-files | ctags --tag-relative -L - -f "$dir/tags.$$" 2>${err_file}; then
+if ctags --tag-relative -Rf$dir/tags.$$ --exclude=.git "$@" 2>${err_file}; then
   mv $dir/tags.$$ $dir/tags
   [ -e ${err_file} ] && rm -f ${err_file}
 else


### PR DESCRIPTION
- use `git rev-parse --git-dir` instead of $GIT_DIR to identify the git directory
- base what files are included in tag generation on the files managed
by git. Exclude files not managed by git