### PR TITLE
Don't capture false positives

### DIFF
--- a/spec/overcommit/hook/pre_commit/es_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/es_lint_spec.rb
@@ -52,6 +52,18 @@ describe Overcommit::Hook::PreCommit::EsLint do
 
       it { should warn }
     end
+
+    context 'and it doesnt count false positives error messages' do
+      before do
+        result.stub(:stdout).and_return([
+          '$ yarn eslint --quiet --format=compact /app/project/Error.ts',
+          '$ /app/project/node_modules/.bin/eslint --quiet --format=compact /app/project/Error.ts',
+          '',
+        ].join("\n"))
+      end
+
+      it { should pass }
+    end
   end
 
   context 'when eslint exits unsucessfully' do


### PR DESCRIPTION
this is a pr to resolve #743. upon thinking about the cause of this problem more i realized that the output causing the false positive was output emitted by [yarn](https://yarnpkg.org/). my initial thought was to write a regex that would capture output that was yarn specific and ignore it, however this makes several assumptions about how other people may be using overcommit. i think it can be much more simple than that. the regex used to capture eslint messages here:
https://github.com/sds/overcommit/blob/6b25f5d60056614c58c5762a9c6e1fe8919742d2/lib/overcommit/hook/pre_commit/es_lint.rb#L33
actually does a really good job at capturing the data needed for overcommit to output information and adding a small tweak to that rule fixes the issue at hand. eslint messages have no whitespace before a file or filepath that has a linting issue, but something like
```bash
$ yarn eslint --quiet --format=compact /app/project/Error.ts
```
does. if we can just simply ignore any lines that DO have whitespace before the `<file>` capture group we can presume that line is not an eslint error or warning message, but some output emitted by some other program (such as yarn).