### PR TITLE
Disable post checkout for homebrew

### DIFF
--- a/spec/integration/disable_overcommit_spec.rb
+++ b/spec/integration/disable_overcommit_spec.rb
@@ -8,7 +8,10 @@ describe 'disabling Overcommit' do
   around do |example|
     repo do
       `overcommit --install > #{File::NULL}`
-      Overcommit::Utils.with_environment('OVERCOMMIT_DISABLE' => overcommit_disable) do
+      Overcommit::Utils.with_environment(
+        'OVERCOMMIT_DISABLE' => overcommit_disable, '
+        HOMEBREW_SYSTEM' => homebrew_system
+        ) do
         touch 'blah'
         `git add blah`
         example.run
@@ -16,9 +19,21 @@ describe 'disabling Overcommit' do
     end
   end
 
-  context 'when the OVERCOMMIT_DISABLE environment variable is set' do
-    let(:overcommit_disable) { '1' }
+  context 'when the HOMEBREW_SYSTEM environment variable is not set' do
+    let(:overcommit_disable) { '0' }
+    let(:homebrew_system) { nil }
+    it 'exits successfully' do
+      subject.status.should == 0
+    end
 
+    it 'runs the hooks' do
+      subject.stderr.should include 'Running pre-commit hooks'
+    end
+  end
+
+  context 'when the HOMEBREW_SYSTEM environment variable is set' do
+    let(:overcommit_disable) { '0' }
+    let(:homebrew_system) { 'Macintosh' }
     it 'exits successfully' do
       subject.status.should == 0
     end
@@ -31,6 +46,7 @@ describe 'disabling Overcommit' do
 
   context 'when the OVERCOMMIT_DISABLE environment variable is set to zero' do
     let(:overcommit_disable) { '0' }
+    let(:homebrew_system) { nil }
 
     it 'exits successfully' do
       subject.status.should == 0
@@ -43,6 +59,7 @@ describe 'disabling Overcommit' do
 
   context 'when the OVERCOMMIT_DISABLE environment variable is unset' do
     let(:overcommit_disable) { nil }
+    let(:homebrew_system) { nil }
 
     it 'exits successfully' do
       subject.status.should == 0

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -19,6 +19,10 @@ if ENV['OVERCOMMIT_DISABLE'].to_i != 0 || ENV['OVERCOMMIT_DISABLED'].to_i != 0
   exit
 end
 
+# Homebrew uses an isolated version of Ruby for installing git repositories
+# Disable Overcommit if the process running is a Homebrew installation.
+exit if ENV['HOMEBREW_SYSTEM']
+
 hook_type = File.basename($0)
 if hook_type == 'overcommit-hook'
   puts "Don't run `overcommit-hook` directly; it is intended to be symlinked " \


### PR DESCRIPTION
Currently you can't install Homebrew taps when you've set overcommit as your default template as mentioned
here (https://github.com/sds/overcommit/issues/591) and here (https://github.com/Homebrew/brew/issues/4577) 

This PR detects when the current git repo is being used by Homebrew and disables overcommit. 
