### PR TITLE
Add parsing of yamllint output

### DIFF
--- a/lib/overcommit/hook/pre_commit/yaml_lint.rb
+++ b/lib/overcommit/hook/pre_commit/yaml_lint.rb
@@ -5,15 +5,34 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://github.com/adrienverge/yamllint
   class YamlLint < Base
+    MESSAGE_REGEX = /
+      ^(?<file>.+)
+      :(?<line>\d+)
+      :(?<col>\d+)
+      :\s\[(?<type>\w+)\]
+      \s(?<msg>.+)$
+    /x
+
     def run
       result = execute(command, args: applicable_files)
+      parse_messages(result.stdout)
+    end
 
-      if result.success?
-        :pass
-      elsif result.stdout.include?('error')
-        [:fail, result.stdout]
-      else
-        [:warn, result.stdout]
+    private
+
+    def parse_messages(output)
+      repo_root = Overcommit::Utils.repo_root
+
+      output.scan(MESSAGE_REGEX).map do |file, line, col, type, msg|
+        line = line.to_i
+        type = type.to_sym
+        # Obtain the path relative to the root of the repository
+        # for nicer output:
+        relpath = file.dup
+        relpath.slice!("#{repo_root}/")
+
+        text = "#{relpath}:#{line}:#{col}:#{type} #{msg}"
+        Overcommit::Hook::Message.new(type, file, line, text)
       end
     end
   end


### PR DESCRIPTION
Parse the yamllint output so Overcommit has per-line awareness of
changes to support problem_on_unmodified_line option.