### PR TITLE
Fix pronto hooks with warning level

### DIFF
--- a/lib/overcommit/hook/shared/pronto.rb
+++ b/lib/overcommit/hook/shared/pronto.rb
@@ -1,19 +1,23 @@
 # frozen_string_literal: true
 
 module Overcommit::Hook::Shared
-  # Shared code used by all Pronto hooks. Runs pronto linter.
+  # Shared code used by all Pronto hooks. Runs pronto linters.
+
+  # @see https://github.com/prontolabs/pronto
   module Pronto
     MESSAGE_TYPE_CATEGORIZER = lambda do |type|
       type.include?('E') ? :error : :warning
     end
+
+    MESSAGE_REGEX = /^(?<file>(?:\w:)?[^:]+):(?<line>\d+) (?<type>[^ ]+)/.freeze
 
     def run
       result = execute(command)
       return :pass if result.success?
 
       extract_messages(
-        result.stdout.split("\n"),
-        /^(?<file>(?:\w:)?[^:]+):(?<line>\d+) (?<type>[^ ]+)/,
+        result.stdout.split("\n").select { |line| line.match?(MESSAGE_REGEX) },
+        MESSAGE_REGEX,
         MESSAGE_TYPE_CATEGORIZER,
       )
     end

--- a/spec/overcommit/hook/pre_commit/pronto_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pronto_spec.rb
@@ -41,10 +41,15 @@ describe Overcommit::Hook::PreCommit::Pronto do
 
     context 'and it reports a warning' do
       before do
-        result.stub(:stdout).and_return([
-          'file1.rb:12 W: Line is too long. [107/80]',
-          'file2.rb:14 I: Prefer single-quoted strings'
-        ].join("\n"))
+        result.stub(:stdout).and_return <<~MESSAGE
+          Running Pronto::Rubocop
+          file1.rb:12 W: Line is too long. [107/80]
+          file2.rb:14 I: Prefer single-quoted strings
+
+          ```suggestion
+          x = 'x'
+          ```
+        MESSAGE
       end
 
       it { should warn }

--- a/spec/overcommit/hook/pre_push/pronto_spec.rb
+++ b/spec/overcommit/hook/pre_push/pronto_spec.rb
@@ -41,10 +41,15 @@ describe Overcommit::Hook::PrePush::Pronto do
 
     context 'and it reports a warning' do
       before do
-        result.stub(:stdout).and_return([
-          'file1.rb:12 W: Line is too long. [107/80]',
-          'file2.rb:14 I: Prefer single-quoted strings'
-        ].join("\n"))
+        result.stub(:stdout).and_return <<~MESSAGE
+          Running Pronto::Rubocop
+          file1.rb:12 W: Line is too long. [107/80]
+          file2.rb:14 I: Prefer single-quoted strings
+
+          ```suggestion
+          x = 'x'
+          ```
+        MESSAGE
       end
 
       it { should warn }


### PR DESCRIPTION
Pronto might report warnings and that was not being correctly parsed by Overcommit. This is sort of a follow-up from #754.

Before: all warnings and errors were reported as errors. They actually simply crashed at https://github.com/sds/overcommit/blob/7d94fa55a74ceea705645d565a34ecefaca08ea5/lib/overcommit/utils/messages_utils.rb#L23-L30

Now warnings and errors are reported correctly. Examples below:
```
# Testing with an output containing only warnings
⋊> ~/w/o/cts on rg-test-branch ⨯ be pronto run --exit-code --commit=qa --runner reek
Running Pronto::Reek
app/models/shipment.rb:163 W: Calls 'loc.type' 3 times - [DuplicateMethodCall](https://github.com/troessner/reek/blob/v6.0.4/docs/Duplicate-Method-Call.md)

⋊> ~/w/o/cts on rg-test-branch ⨯ git push --dry-run origin HEAD # using a hook with reek
Running pre-push hooks
Analyzing with Pronto (brakeman, fasterer, flay and reek)[Pronto] WARNING
app/models/shipment.rb:163 W: Calls 'loc.type' 3 times - [DuplicateMethodCall](https://github.com/troessner/reek/blob/v6.0.4/docs/Duplicate-Method-Call.md)

⚠ All pre-push hooks passed, but with warnings
```

```
# Testing with an output containing warnings AND errors
⋊> ~/w/o/cts on rg-test-branch ⨯ be pronto run --exit-code --commit=qa --runner rubocop
Running Pronto::Rubocop
app/models/shipment.rb:158 E: Layout/MultilineOperationIndentation: Use 2 (not 3) spaces for indenting an expression spanning multiple lines.

 ``suggestion
          loc.status == Models::Location::STATUS_CURRENT
 ``

⋊> ~/w/o/cts on rg-test-branch ⨯ git push --dry-run origin HEAD # using a hook with reek and rubocop
Running pre-push hooks
Analyzing with Pronto (brakeman, fasterer, flay, reek and rubocop)[Pronto] FAILED
app/models/shipment.rb:163 W: Calls 'loc.type' 3 times - [DuplicateMethodCall](https://github.com/troessner/reek/blob/v6.0.4/docs/Duplicate-Method-Call.md)
app/models/shipment.rb:158 E: Layout/MultilineOperationIndentation: Use 2 (not 3) spaces for indenting an expression spanning multiple lines.

✗ One or more pre-push hooks failed

error: failed to push some refs to 'git@github.com:Org/cts'
```