### PR TITLE
Add Vale pre-commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Add `--disable-pending-cops` as default flag to `RuboCop` pre-commit hook to ignore non-existent cops. Requires RuboCop `0.82.0` or newer.
+* Add "ad-hoc" line-aware command hooks
 
 ## 0.58.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## master (unreleased)
 
 * Add `--disable-pending-cops` as default flag to `RuboCop` pre-commit hook to ignore non-existent cops. Requires RuboCop `0.82.0` or newer.
-* Add "ad-hoc" line-aware command hooks
+* Add "ad-hoc" line-aware command hooks.
+* Add `Vale` pre-commit hook to check spelling and style in text and source files.
 
 ## 0.58.0
 

--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ issue](https://github.com/sds/overcommit/issues/238) for more details.
 * [TrailingWhitespace](lib/overcommit/hook/pre_commit/trailing_whitespace.rb)
 * [TravisLint](lib/overcommit/hook/pre_commit/travis_lint.rb)
 * [TsLint](lib/overcommit/hook/pre_commit/ts_lint.rb)
+* Vale
 * [Vint](lib/overcommit/hook/pre_commit/vint.rb)
 * [W3cCss](lib/overcommit/hook/pre_commit/w3c_css.rb)
 * [W3cHtml](lib/overcommit/hook/pre_commit/w3c_html.rb)

--- a/config/default.yml
+++ b/config/default.yml
@@ -842,6 +842,59 @@ PreCommit:
     install_command: 'gem install travis'
     include: '.travis.yml'
 
+  Vale:
+    enabled: false
+    command: "vale"
+    ad_hoc:
+      message_pattern: !ruby/regexp /^(?<file>[^:]+):(?<line>[0-9]+):/
+    flags:
+      - '--output=line'
+    include:
+      # All known extensions for all supported formats are included
+      # (see https://docs.errata.ai/vale/scoping#formats), even
+      # the non-built-in ones that require additional software and/or
+      # configuration: they can be disabled easily using 'exclude':
+      - '**/*.adoc'
+      - '**/*.bsh'
+      - '**/*.c'
+      - '**/*.cc'
+      - '**/*.cpp'
+      - '**/*.cs'
+      - '**/*.css'
+      - '**/*.csx'
+      - '**/*.cxx'
+      - '**/*.dita'
+      - '**/*.java'
+      - '**/*.js'
+      - '**/*.go'
+      - '**/*.h'
+      - '**/*.hpp'
+      - '**/*.hs'
+      - '**/*.html'
+      - '**/*.less'
+      - '**/*.lua'
+      - '**/*.md'
+      - '**/*.php'
+      - '**/*.pl'
+      - '**/*.pm'
+      - '**/*.pod'
+      - '**/*.py'
+      - '**/*.py3'
+      - '**/*.pyi'
+      - '**/*.pyw'
+      - '**/*.R'
+      - '**/*.r'
+      - '**/*.rb'
+      - '**/*.rpy'
+      - '**/*.rst'
+      - '**/*.sass'
+      - '**/*.sbt'
+      - '**/*.scala'
+      - '**/*.swift'
+      - '**/*.txt'
+      - '**/*.xhtml'
+      - '**/*.xml'
+
   Vint:
     enabled: false
     description: 'Analyze with Vint'

--- a/lib/overcommit/utils/messages_utils.rb
+++ b/lib/overcommit/utils/messages_utils.rb
@@ -37,6 +37,14 @@ module Overcommit::Utils
         end
       end
 
+      def create_type_categorizer(warning_pattern)
+        return nil if warning_pattern.nil?
+
+        lambda do |type|
+          type.include?(warning_pattern) ? :warning : :error
+        end
+      end
+
       private
 
       def extract_file(match, message)

--- a/spec/overcommit/hook_loader/plugin_hook_loader_spec.rb
+++ b/spec/overcommit/hook_loader/plugin_hook_loader_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ad-hoc pre-commit hook' do
+  subject do
+    hook_loader = Overcommit::HookLoader::PluginHookLoader.new(
+      config,
+      context,
+      Overcommit::Logger.new(STDOUT)
+    )
+    hooks = hook_loader.load_hooks
+    hooks.find { |h| h.name == hook_name }
+  end
+  let(:config) do
+    config = Overcommit::Configuration.new(
+      YAML.safe_load(config_contents, [Regexp]), {
+        validate: false
+      }
+    )
+    Overcommit::ConfigurationLoader.default_configuration.merge(config)
+  end
+  let(:context) do
+    empty_stdin = File.open(File::NULL) # pre-commit hooks don't take input
+    context = Overcommit::HookContext.create('pre-commit', config, applicable_files, empty_stdin)
+    context
+  end
+
+  around do |example|
+    repo do
+      example.run
+    end
+  end
+
+  describe 'if not line-aware' do
+    let(:config_contents) do
+      <<-'YML'
+        PreCommit:
+          FooGitHook:
+            enabled: true
+            command: "foocmd"
+      YML
+    end
+    let(:hook_name) { 'FooGitHook' }
+    let(:applicable_files) { nil }
+
+    before do
+      context.stub(:execute_hook).with(%w[foocmd]).
+        and_return(result)
+    end
+
+    context 'when command succeeds' do
+      let(:result) do
+        double(success?: true, stdout: '')
+      end
+
+      it { should pass }
+    end
+
+    context 'when command fails' do
+      let(:result) do
+        double(success?: false, stdout: '', stderr: '')
+      end
+
+      it { should fail_hook }
+    end
+  end
+end

--- a/spec/overcommit/hook_loader/plugin_hook_loader_spec.rb
+++ b/spec/overcommit/hook_loader/plugin_hook_loader_spec.rb
@@ -65,4 +65,135 @@ describe 'ad-hoc pre-commit hook' do
       it { should fail_hook }
     end
   end
+
+  describe 'if line-aware' do
+    let(:config_contents) do
+      <<-'YML'
+        PreCommit:
+          FooLint:
+            enabled: true
+            command: ["foo", "lint"]
+            ad_hoc:
+              message_pattern: !ruby/regexp /^(?<file>[^:]+):(?<line>[0-9]+):(?<type>[^ ]+)/
+              warning_message_type_pattern: warning
+            flags:
+            - "--format=emacs"
+            include: '**/*.foo'
+          FooLintDefault:
+            enabled: true
+            command: ["foo", "lint"]
+            ad_hoc:
+              warning_message_type_pattern: warning
+            flags:
+            - "--format=emacs"
+            include: '**/*.foo'
+          FooLintDefaultNoWarnings:
+            enabled: true
+            command: ["foo", "lint"]
+            ad_hoc:
+            flags:
+            - "--format=emacs"
+            include: '**/*.foo'
+      YML
+    end
+    let(:hook_name) { 'FooLint' }
+    let(:applicable_files) { %w[file.foo] }
+
+    before do
+      subject.stub(:applicable_files).and_return(applicable_files)
+      subject.stub(:execute).with(%w[foo lint --format=emacs], args: applicable_files).
+        and_return(result)
+    end
+
+    context 'when command succeeds' do
+      let(:result) do
+        double(success?: true, stdout: '')
+      end
+
+      it { should pass }
+    end
+
+    context 'when command fails with empty stdout' do
+      let(:result) do
+        double(success?: false, stdout: '', stderr: '')
+      end
+
+      it { should pass }
+    end
+
+    context 'when command fails with some warning message' do
+      let(:result) do
+        double(
+          success?: false,
+          stdout: "A:1:warning...\n",
+          stderr: ''
+        )
+      end
+
+      it { should warn }
+    end
+
+    context 'when command fails with some error message' do
+      let(:result) do
+        double(
+          success?: false,
+          stdout: "A:1:???\n",
+          stderr: ''
+        )
+      end
+
+      it { should fail_hook }
+    end
+
+    describe '(using default pattern)' do
+      let(:hook_name) { 'FooLintDefault' }
+
+      context 'when command fails with some warning message' do
+        let(:result) do
+          double(
+            success?: false,
+            stdout: <<-MSG,
+B:1: warning: ???
+            MSG
+            stderr: ''
+          )
+        end
+
+        it { should warn }
+      end
+
+      context 'when command fails with some error message' do
+        let(:result) do
+          double(
+            success?: false,
+            stdout: <<-MSG,
+A:1:80: error
+            MSG
+            stderr: ''
+          )
+        end
+
+        it { should fail_hook }
+      end
+    end
+
+    describe '(using defaults)' do
+      let(:hook_name) { 'FooLintDefaultNoWarnings' }
+
+      context 'when command fails with some messages' do
+        let(:result) do
+          double(
+            success?: false,
+            stdout: <<-MSG,
+A:1:80: error
+B:1: warning: ???
+            MSG
+            stderr: ''
+          )
+        end
+
+        it { should fail_hook }
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Vale](https://github.com/errata-ai/vale) can check both spelling and style in (hyper)text as well as in source files.

**_This depends on https://github.com/sds/overcommit/pull/757 which should be merged first!_** I will rebase this (or merge from master?) after that.

Alas this ad-hoc implementation does not readily support differentiating between warnings and errors. Well, it could, but a project-independent way to reference a file (in this case a Go template) from .overcommit.yml would be needed, see https://github.com/errata-as soon as this is doneai/vale/issues/350.

Limited support is probably still better than nothing! :wink: Also the template for warnings is now out here (see above link), so it could at least be linked to as part of this hook configuration/documentation.

The documentation is indeed just a placeholder for now. Documentation for non-ad-hoc points to their implementation, so what should be done for ad-hoc ones?

Maybe having some manual installation instructions for ad-hoc hooks would be fine too? It is clearly not ideal for users, but after all the individual tools' installations is (also for simplicity reasons) not done automatically either.