### PR TITLE
Support hook type option to `--run`

### DIFF
--- a/lib/overcommit/cli.rb
+++ b/lib/overcommit/cli.rb
@@ -94,8 +94,9 @@ module Overcommit
         @options[:force] = true
       end
 
-      opts.on('-r', '--run', 'Run pre-commit hook against all git tracked files') do
+      opts.on('-r [hook]', '--run [hook]', 'Run specified hook against all git tracked files. Defaults to `pre_commit`.') do |arg|
         @options[:action] = :run_all
+        @options[:hook_to_run] = arg ? arg.to_s : 'run-all'
       end
     end
 
@@ -199,7 +200,7 @@ module Overcommit
 
     def run_all
       empty_stdin = File.open(File::NULL) # pre-commit hooks don't take input
-      context = Overcommit::HookContext.create('run-all', config, @arguments, empty_stdin)
+      context = Overcommit::HookContext.create(@options[:hook_to_run], config, @arguments, empty_stdin)
       config.apply_environment!(context, ENV)
 
       printer = Overcommit::Printer.new(config, log, context)


### PR DESCRIPTION
Sometimes, especially during hook development, you want to force running of a certain type of hook.

This adds an option to the `--run` parameter for specifying a hook type. The default behavior is unchanged.