### PR TITLE
Stylelint Pre-Commit: Fixed Message Regex

### DIFF
--- a/lib/overcommit/hook/pre_commit/stylelint.rb
+++ b/lib/overcommit/hook/pre_commit/stylelint.rb
@@ -8,7 +8,7 @@ module Overcommit::Hook::PreCommit
     # example of output:
     # index.css: line 4, col 4, error - Expected indentation of 2 spaces (indentation)
 
-    MESSAGE_REGEX = /^(?<file>.+):\D*(?<line>\d+).*$/.freeze
+    MESSAGE_REGEX = /^(?<file>[^:]+):\D*(?<line>\d+).*$/.freeze
 
     def run
       result = execute(command, args: applicable_files)


### PR DESCRIPTION
On the rare occasion messages from Stylelint do not match properly with the existing Regex. This change fixes the issue by matching up until the first colon.

Example:
`/app/assets/stylesheets/_example.scss: line 291, col 1, error - Unexpected duplicate selector ".example:first-child:after", first used at line 282 (no-duplicate-selectors)`

Produces:
<img width="1051" alt="Screen Shot 2021-11-12 at 11 44 46 AM" src="https://user-images.githubusercontent.com/3522751/141503212-03d9f832-ab60-4f2b-b583-74291fdf8211.png">
