### PR TITLE
Partial log flushing to make long hooks intuitive

### DIFF
--- a/lib/overcommit/logger.rb
+++ b/lib/overcommit/logger.rb
@@ -31,6 +31,11 @@ module Overcommit
       log
     end
 
+    # Flushes the [IO] object for partial lines
+    def flush
+      @out.flush if @out.respond_to? :flush
+    end
+
     # Write a line of output.
     #
     # A newline character will always be appended.

--- a/lib/overcommit/printer.rb
+++ b/lib/overcommit/printer.rb
@@ -43,16 +43,14 @@ module Overcommit
     end
 
     def interrupt_triggered
-      log.newline
-      log.error 'Interrupt signal received. Stopping hooks...'
+      log.error "\nInterrupt signal received. Stopping hooks..."
     end
 
     # Executed when a hook run was interrupted/cancelled by user.
     def run_interrupted
       log.newline
       log.warning '⚠  Hook run interrupted by user'
-      log.warning '⚠  If files appear modified/missing, check your stash to recover them'
-      log.newline
+      log.warning "⚠  If files appear modified/missing, check your stash to recover them\n"
     end
 
     # Executed when one or more hooks by the end of the run.
@@ -91,6 +89,7 @@ module Overcommit
       log.partial hook.description
       log.partial '.' * [70 - hook.description.length - hook_name.length, 0].max
       log.partial hook_name
+      log.flush
     end
 
     def print_result(hook, status, output) # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'simplecov'
 SimpleCov.start do
   add_filter 'bin/'

--- a/spec/support/git_spec_helpers.rb
+++ b/spec/support/git_spec_helpers.rb
@@ -13,7 +13,7 @@ module GitSpecHelpers
   # @return [String] path of the repository
   def repo(options = {})
     directory('some-repo') do
-      create_cmd = %w[git init]
+      create_cmd = %w[git init --initial-branch=master]
       create_cmd += ['--template', options[:template_dir]] if options[:template_dir]
       create_cmd += ['--separate-git-dir', options[:git_dir]] if options[:git_dir]
 


### PR DESCRIPTION
Today a long hook will not print any output until it is complete.

This change introduces flushing (when available) to the status lines so that a hook will output before its run