### PR TITLE
Fix pronto hooks swallowing generic errors

### DIFF
--- a/lib/overcommit/hook/shared/pronto.rb
+++ b/lib/overcommit/hook/shared/pronto.rb
@@ -15,11 +15,19 @@ module Overcommit::Hook::Shared
       result = execute(command)
       return :pass if result.success?
 
-      extract_messages(
+      # e.g. runtime errors
+      generic_errors = extract_messages(
+        result.stderr.split("\n"),
+        /^(?<type>[a-z]+)/i
+      )
+
+      pronto_infractions = extract_messages(
         result.stdout.split("\n").select { |line| line.match?(MESSAGE_REGEX) },
         MESSAGE_REGEX,
         MESSAGE_TYPE_CATEGORIZER,
       )
+
+      generic_errors + pronto_infractions
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/pronto_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pronto_spec.rb
@@ -31,6 +31,7 @@ describe Overcommit::Hook::PreCommit::Pronto do
 
     context 'and it reports an error' do
       before do
+        result.stub(:stderr).and_return('')
         result.stub(:stdout).and_return([
           'file2.rb:10 E: IDENTICAL code found in :iter.',
         ].join("\n"))
@@ -41,6 +42,7 @@ describe Overcommit::Hook::PreCommit::Pronto do
 
     context 'and it reports a warning' do
       before do
+        result.stub(:stderr).and_return('')
         result.stub(:stdout).and_return <<~MESSAGE
           Running Pronto::Rubocop
           file1.rb:12 W: Line is too long. [107/80]
@@ -53,6 +55,17 @@ describe Overcommit::Hook::PreCommit::Pronto do
       end
 
       it { should warn }
+    end
+
+    context 'and it has a generic error message written to stderr' do
+      before do
+        result.stub(:stdout).and_return('')
+        result.stub(:stderr).and_return([
+          'Could not find pronto in any of the sources'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
     end
   end
 end

--- a/spec/overcommit/hook/pre_push/pronto_spec.rb
+++ b/spec/overcommit/hook/pre_push/pronto_spec.rb
@@ -31,6 +31,7 @@ describe Overcommit::Hook::PrePush::Pronto do
 
     context 'and it reports an error' do
       before do
+        result.stub(:stderr).and_return('')
         result.stub(:stdout).and_return([
           'file2.rb:10 E: IDENTICAL code found in :iter.',
         ].join("\n"))
@@ -41,6 +42,7 @@ describe Overcommit::Hook::PrePush::Pronto do
 
     context 'and it reports a warning' do
       before do
+        result.stub(:stderr).and_return('')
         result.stub(:stdout).and_return <<~MESSAGE
           Running Pronto::Rubocop
           file1.rb:12 W: Line is too long. [107/80]
@@ -53,6 +55,17 @@ describe Overcommit::Hook::PrePush::Pronto do
       end
 
       it { should warn }
+    end
+
+    context 'and it has a generic error message written to stderr' do
+      before do
+        result.stub(:stdout).and_return('')
+        result.stub(:stderr).and_return([
+          'Could not find pronto in any of the sources'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
     end
   end
 end


### PR DESCRIPTION
Found this issue when we were running overcommit on the context of Gemfile that didn't contain `pronto` on it. Ops!
