### PR TITLE
Revert addition of `--disable-pending-cops` flag to RuboCop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -703,7 +703,7 @@ PreCommit:
     enabled: false
     description: 'Analyze with RuboCop'
     required_executable: 'rubocop'
-    flags: ['--format=emacs', '--force-exclusion', '--display-cop-names', '--disable-pending-cops']
+    flags: ['--format=emacs', '--force-exclusion', '--display-cop-names']
     install_command: 'gem install rubocop'
     include:
       - '**/*.gemspec'


### PR DESCRIPTION
It seems like this breaks some other workflows. Prefer the user specifying this themselves if they want it.

Closes #782.
