### PR TITLE
Cut version 0.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Overcommit Changelog
 
+## 0.59.1
+
+* Remove `--disable-pending-cops` as default flag to `RuboCop` pre-commit hook.
+* Remove special handling of process output on Windows since it broke on Linux.
+
 ## 0.59.0
 
 * Add `--disable-pending-cops` as default flag to `RuboCop` pre-commit hook to ignore non-existent cops. Requires RuboCop `0.82.0` or newer.

--- a/lib/overcommit/version.rb
+++ b/lib/overcommit/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module Overcommit
-  VERSION = '0.59.0'
+  VERSION = '0.59.1'
 end


### PR DESCRIPTION
* Remove `--disable-pending-cops` as default flag to `RuboCop` pre-commit hook.
* Remove special handling of process output on Windows since it broke on Linux.
