### PR TITLE
Add non ASCII encoding schema support to RailsSchemaUpToDate hook

### DIFF
--- a/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
+++ b/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
@@ -34,6 +34,10 @@ module Overcommit::Hook::PreCommit
 
     private
 
+    def encoding
+      { encoding: @config['encoding'] }.compact
+    end
+
     def migration_files
       @migration_files ||= applicable_files.select do |file|
         file.match %r{db/migrate/.*\.rb}
@@ -47,7 +51,7 @@ module Overcommit::Hook::PreCommit
     end
 
     def schema
-      @schema ||= schema_files.map { |file| File.read(file) }.join
+      @schema ||= schema_files.map { |file| File.read(file, encoding) }.join
       @schema.tr('_', '')
     end
 


### PR DESCRIPTION
Adds the possibility of adding an encoding config item if you know your `schema.rb` or `structure.sql` file contains non ASCII characters, as in the case of the project I'm working on :grin: 

It's possible you might also want this on migration files, but I haven't included that in this PR, let me know if that's something you'd like to see to get this merged.