### PR TITLE
Add optional additional local configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ PreCommit:
     command: ['bundle', 'exec', 'rubocop'] # Invoke within Bundler context
 ```
 
+Additionally, you may wish to have repo-specific configurations that are local to your computer that are not part of the shared repo config.
+Adding a `.local-overcommit.yml` file in the top-level directory of the repository adds another configuration file. This file works the same as `.overcommit.yml`.
+Adding this to ignored files in a git repo will allow you to have a local configuration per repo.
+
 ### Hook Options
 
 Individual hooks expose both built-in configuration options as well as their

--- a/lib/overcommit/constants.rb
+++ b/lib/overcommit/constants.rb
@@ -4,6 +4,7 @@
 module Overcommit
   HOME = File.expand_path(File.join(File.dirname(__FILE__), '..', '..')).freeze
   CONFIG_FILE_NAME = '.overcommit.yml'
+  LOCAL_CONFIG_FILE_NAME = '.local-overcommit.yml'
 
   HOOK_DIRECTORY = File.join(HOME, 'lib', 'overcommit', 'hook').freeze
 


### PR DESCRIPTION
Adds support for an additional configuration file, `.local-overcommit.yml`, in order to allow local configuration on a local computer. That way the main config `.overcommit.yml` can be commited to a repo and a local developer can also add configurations to this new file that do not have to live in the main config.