### PR TITLE
Add `MixFormat` hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -536,6 +536,16 @@ PreCommit:
     required_executable: 'grep'
     flags: ['-IHn', "^<<<<<<<[ \t]"]
 
+  MixFormat:
+    enabled: false
+    description: 'Check formatting with mix format'
+    required_executable: 'mix'
+    flags: ['format', '--check-formatted']
+    include:
+      - '**/*.ex'
+      - '**/*.heex'
+      - '**/*.exs'
+
   PuppetMetadataJsonLint:
     enabled: false
     description: 'Checking module metadata'

--- a/lib/overcommit/hook/pre_commit/mix_format.rb
+++ b/lib/overcommit/hook/pre_commit/mix_format.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Overcommit::Hook::PreCommit
+  # Runs `mix format --check-formatted` against any modified ex/heex/exs files.
+  #
+  # @see https://hexdocs.pm/mix/main/Mix.Tasks.Format.html
+  class MixFormat < Base
+    # example message:
+    # ** (Mix) mix format failed due to --check-formatted.
+    # The following files are not formatted:
+    #
+    #   * lib/file1.ex
+    #   * lib/file2.ex
+    FILES_REGEX = /^\s+\*\s+(?<file>.+)$/.freeze
+
+    def run
+      result = execute(command, args: applicable_files)
+      return :pass if result.success?
+
+      result.stderr.scan(FILES_REGEX).flatten.
+        map { |file| message(file) }
+    end
+
+    private
+
+    def message(file)
+      Overcommit::Hook::Message.new(:error, file, nil, file)
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/mix_format_spec.rb
+++ b/spec/overcommit/hook/pre_commit/mix_format_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::MixFormat do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.ex file2.exs])
+  end
+
+  context 'when mix format exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when mix format exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return('')
+        result.stub(:stderr).and_return([
+          '** (Mix) mix format failed due to --check-formatted.',
+          'The following files are not formatted:',
+          '',
+          '  * lib/file1.ex',
+          '  * lib/file2.ex'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Elixir has a built-in formatter that can be run with `mix format` to format the code and `mix format --check-formatted` to list out files which aren't formatted.

This was modeled after the credo hook, but in this case we only get the file list in the output to stderr so that's what we display in the error output.