### PR TITLE
support trailing space in replace_branch's 'replacement_text' config

### DIFF
--- a/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb
+++ b/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb
@@ -11,9 +11,9 @@ module Overcommit::Hook::PrepareCommitMsg
   # For instance, if your current branch is `123-topic` then this config
   #
   #    branch_pattern: '(\d+)-(\w+)'
-  #    replacement_text: '[#\1]'
+  #    replacement_text: '[#\1] '
   #
-  # would make this hook prepend commit messages with `[#123]`.
+  # would make this hook prepend commit messages with `[#123] `.
   #
   # Similarly, a replacement text of `[\1][\2]` would result in `[123][topic]`.
   #
@@ -53,7 +53,7 @@ module Overcommit::Hook::PrepareCommitMsg
       @new_template ||=
         begin
           curr_branch = Overcommit::GitRepo.current_branch
-          curr_branch.gsub(branch_pattern, replacement_text).strip
+          curr_branch.gsub(branch_pattern, replacement_text)
         end
     end
 
@@ -69,7 +69,7 @@ module Overcommit::Hook::PrepareCommitMsg
       @replacement_text ||=
         begin
           if File.exist?(replacement_text_config)
-            File.read(replacement_text_config)
+            File.read(replacement_text_config).chomp
           else
             replacement_text_config
           end

--- a/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
+++ b/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
@@ -62,6 +62,14 @@ describe Overcommit::Hook::PrepareCommitMsg::ReplaceBranch do
       it 'prepends the replacement text' do
         expect(File.read('COMMIT_EDITMSG')).to eq("[#123]\n")
       end
+
+      context 'when the replacement text contains a space' do
+        let(:config) { new_config('replacement_text' => '[\1] ') }
+
+        it 'prepends the replacement text, including the space' do
+          expect(File.read('COMMIT_EDITMSG')).to eq("[123] \n")
+        end
+      end
     end
 
     context "when the checked out branch doesn't matches the pattern" do


### PR DESCRIPTION
## Changes
- support trailing spaces in `PrepareCommitMsg::ReplaceBranch`'s `replacement_text` pattern

## Issue

- When on a branch named `JIRA-123-fix-another-issue`
- And using the below overcommit config
- When I run `git commit -m 'test'` 
- Then I should have commit message `[JIRA-123] test`
  - ERROR: I actually get  `[JIRA-123]test`

```
PrepareCommitMsg:
  ReplaceBranch:
    enabled: true
    branch_pattern: '\A([A-Za-z]{1,10}-?[0-9]+).*\z' # JIRA-123-some-branch
    replacement_text: '[\1] ' # [JIRA-123] commit message
    skipped_commit_types: ['merge', 'squash']
```