### PR TITLE
Rescue Psych::DisallowedClass in YamlSyntax

### DIFF
--- a/lib/overcommit/hook/pre_commit/yaml_syntax.rb
+++ b/lib/overcommit/hook/pre_commit/yaml_syntax.rb
@@ -15,10 +15,19 @@ module Overcommit::Hook::PreCommit
           rescue ArgumentError, Psych::SyntaxError => e
             messages << Overcommit::Hook::Message.new(:error, file, nil, e.message)
           end
+        rescue Psych::DisallowedClass => e                                                           
+          messages << error_message(file, e)                                                         
         end
       end
 
       messages
+    end
+    
+    private                                                                                          
+                                                                                                     
+    def error_message(file, error)                                                                   
+      text = "#{file}: #{error.message}"                                                             
+      Overcommit::Hook::Message.new(:error, file, nil, text)                                         
     end
   end
 end

--- a/lib/overcommit/hook/pre_commit/yaml_syntax.rb
+++ b/lib/overcommit/hook/pre_commit/yaml_syntax.rb
@@ -15,19 +15,19 @@ module Overcommit::Hook::PreCommit
           rescue ArgumentError, Psych::SyntaxError => e
             messages << Overcommit::Hook::Message.new(:error, file, nil, e.message)
           end
-        rescue Psych::DisallowedClass => e                                                           
-          messages << error_message(file, e)                                                         
+        rescue Psych::DisallowedClass => e
+          messages << error_message(file, e)
         end
       end
 
       messages
     end
-    
-    private                                                                                          
-                                                                                                     
-    def error_message(file, error)                                                                   
-      text = "#{file}: #{error.message}"                                                             
-      Overcommit::Hook::Message.new(:error, file, nil, text)                                         
+
+    private
+
+    def error_message(file, error)
+      text = "#{file}: #{error.message}"
+      Overcommit::Hook::Message.new(:error, file, nil, text)
     end
   end
 end


### PR DESCRIPTION
This improves the output for errors safe loading disallowed classes with psych 5.0

It would be nice to offer a way to specify `permitted_classes` somewhere. https://ruby-doc.org/3.2.0/exts/psych/Psych.html