### PR TITLE
Allow ReplaceBranch to use skip_if

### DIFF
--- a/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb
+++ b/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb
@@ -29,6 +29,7 @@ module Overcommit::Hook::PrepareCommitMsg
   # - 'squash'   - if squashing
   #
   class ReplaceBranch < Base
+
     DEFAULT_BRANCH_PATTERN = /\A(\d+)-(\w+).*\z/.freeze
 
     def run
@@ -85,7 +86,7 @@ module Overcommit::Hook::PrepareCommitMsg
     end
 
     def skip?
-      skipped_commit_types.include?(commit_message_source)
+      super || skipped_commit_types.include?(commit_message_source)
     end
   end
 end

--- a/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
+++ b/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
@@ -70,6 +70,26 @@ describe Overcommit::Hook::PrepareCommitMsg::ReplaceBranch do
           expect(File.read('COMMIT_EDITMSG')).to eq("[123] \n")
         end
       end
+
+      context 'when skip_if exits with a zero status' do
+        let(:config) { new_config('skip_if' => ['/bin/sh', '-c', 'exit 0']) }
+
+        it { is_expected.to pass }
+
+        it 'does not change the commit message' do
+          expect(File.read('COMMIT_EDITMSG')).to eq("\n")
+        end
+      end
+
+      context 'when skip_if exits with a non-zero status' do
+        let(:config) { new_config('skip_if' => ['/bin/sh', '-c', 'exit 1']) }
+
+        it { is_expected.to pass }
+
+        it 'does not change the commit message' do
+          expect(File.read('COMMIT_EDITMSG')).to eq("[#123]\n")
+        end
+      end
     end
 
     context "when the checked out branch doesn't matches the pattern" do


### PR DESCRIPTION
This bug fix allows for `skip_if` to be used with `ReplaceBranch`.