### PR TITLE
fix: local overcommit file merges with existing .overcommit.yml file

### DIFF
--- a/lib/overcommit/configuration_loader.rb
+++ b/lib/overcommit/configuration_loader.rb
@@ -70,11 +70,9 @@ module Overcommit
     # Loads a configuration, ensuring it extends the default configuration.
     def load_file(file, local_file = nil)
       overcommit_config = self.class.load_from_file(file, default: false, logger: @log)
-      if local_file
-        local_config = self.class.load_from_file(local_file, default: false, logger: @log)
-      end
+      l_config = self.class.load_from_file(local_file, default: false, logger: @log) if local_file
       config = self.class.default_configuration.merge(overcommit_config)
-      config = self.class.default_configuration.merge(local_config) if local_config
+      config = config.merge(l_config) if l_config
 
       if @options.fetch(:verify) { config.verify_signatures? }
         verify_signatures(config)


### PR DESCRIPTION
The .local-overcommit.yml did not work as intended. When a repo level .overcommit.yml and .local-overcommit.yml both existed, only the latter applied. Further, the tests only checked that each file was loaded, not that the configs included the expected overrides.

This PR refactors:
- Specs:
  - When .overcommit.yml exists, applies settings and has default settings still
  - When both .local-overcommit.yml and .overcommit.yml exists has default settings and both files settings applied
- Logic to merge the .overcommit.yml file to default settings and if it exists, .local-overcommit.yml file to both