### PR TITLE
Explicitly delegate encoding keyword arguments to File.read (Issue #829)

### DIFF
--- a/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
+++ b/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
@@ -53,7 +53,7 @@ module Overcommit::Hook::PreCommit
     end
 
     def schema
-      @schema ||= schema_files.map { |file| File.read(file, encoding) }.join
+      @schema ||= schema_files.map { |file| File.read(file, **(encoding || {})) }.join
       @schema.tr('_', '')
     end
 


### PR DESCRIPTION
Makes `RailsSchemaUpToDate` pre-commit hook compatible with Ruby 3.
Fixes #829.