### PR TITLE
Explicitly define joined Threads in PrepareCommitMsg concurrency spec

### DIFF
--- a/spec/overcommit/hook/prepare_commit_msg/base_spec.rb
+++ b/spec/overcommit/hook/prepare_commit_msg/base_spec.rb
@@ -38,9 +38,9 @@ describe Overcommit::Hook::PrepareCommitMsg::Base do
           contents + "bravo\n"
         end
       end
-      Thread.new { hook_1.run }
-      Thread.new { hook_2.run }
-      Thread.list.each { |t| t.join unless t == Thread.current }
+      t1 = Thread.new { hook_1.run }
+      t2 = Thread.new { hook_2.run }
+      [t1, t2].each(&:join)
       expect(File.read(tempfile)).to match(/alpha\n#{initial_content}bravo\n/m)
     end
   end


### PR DESCRIPTION
Fixes #838 