### PR TITLE
Support stylelint 16+, which emits messages on stderr

### DIFF
--- a/lib/overcommit/hook/pre_commit/stylelint.rb
+++ b/lib/overcommit/hook/pre_commit/stylelint.rb
@@ -12,7 +12,7 @@ module Overcommit::Hook::PreCommit
 
     def run
       result = execute(command, args: applicable_files)
-      output = result.stdout.chomp
+      output = result.stdout + result.stderr.chomp
       return :pass if result.success? && output.empty?
 
       extract_messages(

--- a/spec/overcommit/hook/pre_commit/stylelint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/stylelint_spec.rb
@@ -15,6 +15,7 @@ describe Overcommit::Hook::PreCommit::Stylelint do
     before do
       result = double('result')
       result.stub(:success?).and_return(true)
+      result.stub(:stderr).and_return('')
       result.stub(:stdout).and_return('')
       subject.stub(:execute).and_return(result)
     end
@@ -22,7 +23,7 @@ describe Overcommit::Hook::PreCommit::Stylelint do
     it { should pass }
   end
 
-  context 'when stylelint exits unsucessfully' do
+  context 'when stylelint exits unsucessfully with messages on stdout (stylelint < 16)' do
     let(:result) { double('result') }
 
     before do
@@ -32,7 +33,33 @@ describe Overcommit::Hook::PreCommit::Stylelint do
     context 'and it reports an error' do
       before do
         result.stub(:success?).and_return(false)
+        result.stub(:stderr).and_return('')
         result.stub(:stdout).and_return([
+          'index.css: line 4, col 4, error - Expected indentation of 2 spaces (indentation)',
+          'form.css: line 10, col 6, error - Expected indentation of 4 spaces (indentation)',
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+
+      it 'extracts lines numbers correctly from output' do
+        expect(subject.run.map(&:line)).to eq([4, 10])
+      end
+    end
+  end
+
+  context 'when stylelint exits unsucessfully with messages on stderr (stylelint >= 16)' do
+    let(:result) { double('result') }
+
+    before do
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:success?).and_return(false)
+        result.stub(:stdout).and_return('')
+        result.stub(:stderr).and_return([
           'index.css: line 4, col 4, error - Expected indentation of 2 spaces (indentation)',
           'form.css: line 10, col 6, error - Expected indentation of 4 spaces (indentation)',
         ].join("\n"))


### PR DESCRIPTION
Before Stylelint 16, Stylelint emitted its messages on stdout. Hence Overcommit's Stylelint hook was built to read output from stdout.

Starting with Stylelint 16, Stylelint now emits its messages to stderr, which means the existing Overcommit implementation no longer works.

This PR updates Overcommit's Stylelint plugin to check for messages on _both_ stdout and stderr. That way <16 and >=16 versions of Stylelint are supported.

Fixes #823