### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
         os:
           - ubuntu
           # At the moment of this commit various specs fail on Windows.


### PR DESCRIPTION
It might be a good idea to also update the `main` branch protection rules to require that the 3.2 and 3.3 jobs succeed. Right now only 2.7, 3.0, and 3.1 are required. A repository admin will need to make this change.