### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -15,6 +15,10 @@ Gem::Specification.new do |s|
   s.post_install_message  =
     'Install hooks by running `overcommit --install` in your Git repository'
 
+  s.metadata = {
+    "changelog_uri" => "https://github.com/sds/overcommit/blob/main/CHANGELOG.md"
+  }
+
   s.require_paths         = %w[lib]
 
   s.executables           = ['overcommit']

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     'Install hooks by running `overcommit --install` in your Git repository'
 
   s.metadata = {
-    "changelog_uri" => "https://github.com/sds/overcommit/blob/main/CHANGELOG.md"
+    'changelog_uri' => 'https://github.com/sds/overcommit/blob/main/CHANGELOG.md'
   }
 
   s.require_paths         = %w[lib]


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater