### PR TITLE
 Expand tildes(~) for hooksPath

### DIFF
--- a/lib/overcommit/git_config.rb
+++ b/lib/overcommit/git_config.rb
@@ -17,7 +17,7 @@ module Overcommit
       path = `git config --get core.hooksPath`.chomp
       return File.join(Overcommit::Utils.git_dir, 'hooks') if path.empty?
 
-      File.absolute_path(path, Dir.pwd)
+      File.expand_path(path, Dir.pwd)
     end
   end
 end

--- a/spec/overcommit/git_config_spec.rb
+++ b/spec/overcommit/git_config_spec.rb
@@ -89,6 +89,7 @@ describe Overcommit::GitConfig do
 
       it 'returns the absolute path to the folder in the users home path' do
         expect(subject).to eq File.expand_path('~/my-hooks')
+        expect(subject).not_to include('~')
       end
     end
   end

--- a/spec/overcommit/git_config_spec.rb
+++ b/spec/overcommit/git_config_spec.rb
@@ -78,5 +78,18 @@ describe Overcommit::GitConfig do
         expect(subject).to eq File.expand_path('my-hooks')
       end
     end
+
+    context 'when explicitly set to a path starting with a tilde' do
+      around do |example|
+        repo do
+          `git config --local core.hooksPath ~/my-hooks`
+          example.run
+        end
+      end
+
+      it 'returns the absolute path to the folder in the users home path' do
+        expect(subject).to eq File.expand_path('~/my-hooks')
+      end
+    end
   end
 end


### PR DESCRIPTION
While installing overcommit git hooks i noticed that tildes are not expanded to home folders for the `hooksPath` config, the result was a tilde folder in the current directory.

This PR addresses that by switching `File.absolute_path` to `File.expand_path`. The [underlaying implementation](https://github.com/ruby/ruby/blob/v3_3_4/file.c#L3753) in Ruby is exactly the same just with this difference in how `~` is handled.