### PR TITLE
Fix spec compatibility with recent git versions

### DIFF
--- a/spec/integration/resolving_cherry_pick_conflict_spec.rb
+++ b/spec/integration/resolving_cherry_pick_conflict_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'resolving cherry-pick conflicts' do
-  subject { shell(%w[git commit -m "Resolve conflicts" -i some-file]) }
+  subject { shell(%w[git commit -m Test -i some-file]) }
 
   let(:config) { <<-YML }
     PreCommit:

--- a/spec/integration/resolving_merge_conflict_spec.rb
+++ b/spec/integration/resolving_merge_conflict_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'resolving merge conflicts' do
-  subject { shell(%w[git commit -m "Resolve conflicts" -i some-file]) }
+  subject { shell(%w[git commit -m Test -i some-file]) }
 
   around do |example|
     repo do


### PR DESCRIPTION
The original array was defining the shellwords like this:
`["git", "commit", "-m", "\"Resolve", "conflicts\"", "-i", "some-file"]`

This combined with the most recent git version failed with:
```
error: pathspec 'conflicts"' did not match any file(s) known to git
```

This PR just simplifies the commit message to work with the %w array literal.