### PR TITLE
Bump rexml to >= 3.3.9 to resolve GHSA-2rxp-v6pw-ch6m

### DIFF
--- a/lib/overcommit/version.rb
+++ b/lib/overcommit/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module Overcommit
-  VERSION = '0.64.0'
+  VERSION = '0.64.1'
 end

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency          'childprocess', '>= 0.6.3', '< 6'
   s.add_dependency          'iniparse', '~> 1.4'
-  s.add_dependency          'rexml', '~> 3.2'
+  s.add_dependency          'rexml', '>= 3.3.9'
 end


### PR DESCRIPTION
A `ReDoS vulnerability in REXML` has been identified in versions <3.3.9

Details in GitHub:
 - https://github.com/ruby/rexml/security/advisories/GHSA-2rxp-v6pw-ch6m

This is a small bump to the latest patched version. This should resolve anybody getting the following `bundle audit` error when using overcommit:

```
Name: rexml
Version: 3.3.8
CVE: CVE-2024-49761
GHSA: GHSA-2rxp-v6pw-ch6m
Criticality: High
URL: https://github.com/ruby/rexml/security/advisories/GHSA-2rxp-v6pw-ch6m
Title: REXML ReDoS vulnerability
Solution: update to '>= 3.3.9'
```