### PR TITLE
Load bundled gems on expected version

### DIFF
--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
@@ -32,17 +27,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -27,10 +27,11 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml')
+config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+gemfile = Regexp.last_match(1)
 
-if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
+if gemfile
+  ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler'
 
   begin

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -32,17 +32,10 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-require 'yaml'
-# rubocop:disable Style/RescueModifier
-gemfile =
-  begin
-    YAML.load_file('.overcommit.yml', aliases: true)['gemfile']
-  rescue ArgumentError
-    YAML.load_file('.overcommit.yml')['gemfile']
-  end rescue nil
+config = File.read('.overcommit.yml')
 
-if gemfile
-  ENV['BUNDLE_GEMFILE'] = gemfile
+if config =~ /gemfile: "?(.*)"?/
+  ENV['BUNDLE_GEMFILE'] = $1
   require 'bundler'
 
   begin

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -30,7 +30,7 @@ end
 config = File.read('.overcommit.yml')
 
 if config =~ /gemfile: "?(.*)"?/
-  ENV['BUNDLE_GEMFILE'] = $1
+  ENV['BUNDLE_GEMFILE'] = Regexp.last_match(1)
   require 'bundler'
 
   begin

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+begin
+  require "bundler/setup"
+rescue LoadError
+end
+
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -27,7 +27,7 @@ if hook_type == 'overcommit-hook'
 end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
-config = File.read('.overcommit.yml') =~ /gemfile: "?(.*)"?/
+config = File.read('.overcommit.yml') =~ /gemfile: ['"]?(.*)['"]?/
 gemfile = Regexp.last_match(1)
 
 if gemfile

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -1,11 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-begin
-  require "bundler/setup"
-rescue LoadError
-end
-
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.


### PR DESCRIPTION
Fixes https://github.com/sds/overcommit/issues/789

`psych` is no longer a default gem, but current and old ruby still ships with it. When we `require 'yaml'`, we activate that gem in whatever version that is bundled with ruby. Later on, we load bundler, and we `Bundler.setup`, which will then activate whatever version specified in the lock file. More often than not, they might not match.

The approach in this PR is to strip the `yaml` dependency completely from the hook scripts, while retaining the ability to configure the Gemfile using it.