### PR TITLE
Add note about unsupported YAML features in `gemfile:` line in default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -32,6 +32,10 @@
 # your repository, and then set the `gemfile` option below to the name you gave
 # the file.
 # (Generate lock file by running `bundle install --gemfile=.overcommit_gems.rb`)
+#
+# NOTE: the following line will be parsed by a regexp rather than a proper YAML
+# parser, so avoid any values other than false or a string, and don't use inline
+# comments
 gemfile: false
 
 # Where to store hook plugins specific to a repository. These are loaded in


### PR DESCRIPTION
Related to #863 and [this comment](https://github.com/sds/overcommit/issues/862#issuecomment-2641924147):

> Having a similar problem since we had this line in our `.overcommit.yml`:
> 
> ```yaml
> gemfile: Gemfile # enforce bundled version of overcommit
> ```
>
> And now overcommit doesn't strip out the inline comment, resulting in this weird looking error message:
>
> ```
> Problem loading 'Gemfile # enforce bundled version of overcommit': /path/to/project/Gemfile # enforce bundled version of overcommit not found
> ```

I think adding support for comments in the `gemfile:` regexp is likely overkill and may still not be enough when the next person tries to use yet another YAML feature in that line, but perhaps this little warning would help someone else avoid tripping.