### PR TITLE
adds 'set' requirements to diff hook context.

### DIFF
--- a/lib/overcommit/hook_context/diff.rb
+++ b/lib/overcommit/hook_context/diff.rb
@@ -2,6 +2,8 @@
 
 require 'overcommit/git_repo'
 
+require 'set'
+
 module Overcommit::HookContext
   # Simulates a pre-commit context based on the diff with another git ref.
   #


### PR DESCRIPTION
Running `overcommit` with the `--diff` flag results in errors for version `0.67.0`.

```sh
bundle exec overcommit --diff HEAD
```

It results on the following:

```ruby
Running pre-commit hooks
Check for case-insensitivity conflicts................[CaseConflicts] FAILED
Hook raised unexpected error
uninitialized constant Overcommit::Hook::PreCommit::CaseConflicts::Set

      repo_files = Set.new(applicable_files)
                   ^^^
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook/pre_commit/case_conflicts.rb:8:in `run'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook/base.rb:47:in `block in run_and_transform'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/utils.rb:260:in `with_environment'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook/base.rb:47:in `run_and_transform'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:162:in `run_hook'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:98:in `block in consume'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:94:in `loop'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:94:in `consume'
Analyze with RuboCop........................................[RuboCop] FAILED
Hook raised unexpected error
uninitialized constant Overcommit::GitRepo::Set

      lines = Set.new
              ^^^
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/git_repo.rb:69:in `extract_modified_lines'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_context/diff.rb:17:in `modified_lines_in_file'
/nix/store/0sj7d3r1kf95f27028j93j0sx3v6p1kw-ruby-3.1.6/lib/ruby/3.1.0/forwardable.rb:238:in `modified_lines_in_file'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/message_processor.rb:145:in `message_on_modified_line?'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/message_processor.rb:138:in `block in remove_ignored_messages'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/message_processor.rb:138:in `select'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/message_processor.rb:138:in `remove_ignored_messages'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/message_processor.rb:45:in `handle_modified_lines'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/message_processor.rb:39:in `hook_result'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook/base.rb:263:in `process_hook_return_value'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook/base.rb:48:in `run_and_transform'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:162:in `run_hook'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:98:in `block in consume'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:94:in `loop'
.bundle/ruby/3.1.0/gems/overcommit-0.67.0/lib/overcommit/hook_runner.rb:94:in `consume'

✗ One or more pre-commit hooks failed
```

The problems are fixed once `set` is required in the context that the sub command is run.

`run_all.rb` also requires `set` where the module is [defined](https://github.com/sds/overcommit/blob/main/lib/overcommit/hook_context/run_all.rb#L3).