### PR TITLE
Update RuboCop in Gemfile to silence a deprecation warning in build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,7 +70,7 @@ Naming/FileName:
 
 # Renaming `has_something?` to `something?` obfuscates whether it is a "is-a" or
 # a "has-a" relationship.
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 # commit_sha1 is indeed how we want to write such a variable, so ignore this cop

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'simplecov-lcov', '~> 0.8.0'
 if RUBY_VERSION < '2.7.0'
   gem 'rubocop', '1.50.0'
 else
-  gem 'rubocop', '1.59.0'
+  gem 'rubocop', '1.77.0'
 end
 
 gem 'ffi' if Gem.win_platform?

--- a/lib/overcommit/hook/pre_commit/scalastyle.rb
+++ b/lib/overcommit/hook/pre_commit/scalastyle.rb
@@ -24,7 +24,7 @@ module Overcommit::Hook::PreCommit
       extract_messages(
         messages,
         MESSAGE_REGEX,
-        &:to_sym
+        lambda(&:to_sym)
       )
     end
   end

--- a/lib/overcommit/hook/pre_commit/scalastyle.rb
+++ b/lib/overcommit/hook/pre_commit/scalastyle.rb
@@ -24,7 +24,7 @@ module Overcommit::Hook::PreCommit
       extract_messages(
         messages,
         MESSAGE_REGEX,
-        lambda { |type| type.to_sym }
+        &:to_sym
       )
     end
   end

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -42,7 +42,6 @@ if gemfile
     exit 78 # EX_CONFIG
   end
 end
-# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'


### PR DESCRIPTION
The existing version of RuboCop no longer works against other libraries without deprecation warnings; rather than lock more dependencies, upgrade RuboCop used in project.

```sh
Running pre-commit hooks
Check YAML syntax........................................[YamlSyntax] OK
Check Gemfile dependencies..............................[BundleCheck] OK
Check for trailing whitespace....................[TrailingWhitespace] OK
Analyze with RuboCop........................................[RuboCop] FAILED
Unexpected output: unable to determine line number or type of error/warning for output:
`EnsureNode#body` is deprecated and will be changed in the next major version of rubocop-ast. Use `EnsureNode#branch` instead to get the body of the `ensure` branch.
Called from:
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/layout/indentation_width.rb:67:in `on_ensure'
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/commissioner.rb:107:in `public_send'
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/commissioner.rb:107:in `block (2 levels) in trigger_responding_cops'
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/commissioner.rb:171:in `with_cop_error_handling'
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/commissioner.rb:106:in `block in trigger_responding_cops'
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/commissioner.rb:105:in `each'
/Users/broz/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-1.63.0/lib/rubocop/cop/commissioner.rb:105:in
`trigger_responding_cops'
[...]
```