### PR TITLE
Make hook context input reads thread-safe

### DIFF
--- a/lib/overcommit/hook_context/base.rb
+++ b/lib/overcommit/hook_context/base.rb
@@ -24,6 +24,7 @@ module Overcommit::HookContext
       @args = args
       @input = input
       @options = options
+      @input_mutex = Mutex.new
     end
 
     # Executes a command as if it were a regular git hook, passing all
@@ -95,7 +96,13 @@ module Overcommit::HookContext
     #
     # @return [String]
     def input_string
-      @input_string ||= @input.read
+      return @input_string if defined?(@input_string)
+
+      @input_mutex.synchronize do
+        @input_string = @input.read unless defined?(@input_string)
+      end
+
+      @input_string
     end
 
     # Returns an array of lines passed to the hook via the standard input

--- a/spec/overcommit/hook_context/base_spec.rb
+++ b/spec/overcommit/hook_context/base_spec.rb
@@ -26,6 +26,57 @@ describe Overcommit::HookContext::Base do
     it { should == ['line 1', 'line 2'] }
   end
 
+  describe '#input_string' do
+    let(:input_class) do
+      Class.new do
+        attr_reader :read_count
+
+        def initialize(value)
+          @value = value
+          @read_count = 0
+          @lock = Mutex.new
+          @read_started = Queue.new
+          @read_finished = Queue.new
+        end
+
+        def read
+          @lock.synchronize do
+            @read_count += 1
+            raise 'input stream was read more than once' if @read_count > 1
+          end
+
+          @read_started << true
+          @read_finished.pop
+          @value
+        end
+
+        def wait_until_reading
+          @read_started.pop
+        end
+
+        def finish_reading
+          @read_finished << true
+        end
+      end
+    end
+
+    let(:input) { input_class.new("line 1\nline 2\n") }
+
+    it 'shares one input stream read across concurrent callers' do
+      first_reader = Thread.new { context.input_string }
+      input.wait_until_reading
+
+      second_reader = Thread.new { context.input_string }
+      Thread.pass until second_reader.status == 'sleep'
+
+      input.finish_reading
+      results = [first_reader, second_reader].map(&:value)
+
+      results.should == Array.new(2, "line 1\nline 2\n")
+      input.read_count.should == 1
+    end
+  end
+
   describe '#post_fail_message' do
     subject { context.post_fail_message }
 


### PR DESCRIPTION
## Summary

This fixes a small race in `HookContext::Base#input_string`.

Hook contexts currently cache stdin lazily with `@input_string ||= @input.read`. Since hooks are parallelized by default, two hooks sharing the same context can race during that first read. For hook types that receive real data on stdin, such as `pre-push`, one hook can consume the stream while another reads EOF and caches an empty string.

If that happens, helpers like `pushed_refs` can silently see no refs even though Git did provide them.

## Changes

- Add a mutex around the first `input_string` read so the stream is consumed once.
- Keep the cached string shared by all callers after the initial read.
- Add a spec that forces a concurrent read attempt without relying on flaky timing.

This follows up on #881.

## Verification

Focused checks pass locally:

```sh
bundle exec rspec spec/overcommit/hook_context/base_spec.rb
bundle exec rubocop lib/overcommit/hook_context/base.rb spec/overcommit/hook_context/base_spec.rb
bundle exec overcommit --run
```

I also ran the full spec suite. It still has a few unrelated failures around git alias amendment detection on my machine, but this change's focused spec passes.
