### PR TITLE
Fail Flay hook when flay crashes instead of silently passing

### DIFF
--- a/lib/overcommit/hook/pre_commit/flay.rb
+++ b/lib/overcommit/hook/pre_commit/flay.rb
@@ -24,6 +24,13 @@ module Overcommit::Hook::PreCommit
       # Run the command for each file
       applicable_files.each do |file|
         result = execute(command, args: [file])
+        # flay exits non-zero both when it finds duplication (with output on
+        # stdout) and when it crashes internally. A crash leaves stdout empty
+        # and writes a backtrace to stderr, so treat that as an error instead
+        # of silently passing.
+        if !result.success? && result.stdout.strip.empty?
+          return :fail, result.stderr
+        end
         results = result.stdout.split("\n\n")
         results.shift
         unless results.empty?

--- a/lib/overcommit/hook/pre_commit/flay.rb
+++ b/lib/overcommit/hook/pre_commit/flay.rb
@@ -31,6 +31,7 @@ module Overcommit::Hook::PreCommit
         if !result.success? && result.stdout.strip.empty?
           return :fail, result.stderr
         end
+
         results = result.stdout.split("\n\n")
         results.shift
         unless results.empty?

--- a/spec/overcommit/hook/pre_commit/flay_spec.rb
+++ b/spec/overcommit/hook/pre_commit/flay_spec.rb
@@ -57,4 +57,16 @@ Total score (lower is better) = 0
 
     it { should pass }
   end
+
+  context 'flay crashed with no output on stdout' do
+    let(:result) do
+      double(
+        success?: false,
+        stdout: '',
+        stderr: "undefined method `line' for nil:NilClass (NoMethodError)"
+      )
+    end
+
+    it { should fail_hook }
+  end
 end


### PR DESCRIPTION
The Flay hook only inspects `result.stdout`, so when `flay` crashes (non-zero exit, backtrace on stderr, empty stdout) the hook treats it as "no duplication found" and passes silently. This guards that case: if flay exits non-zero with no stdout, the hook now fails and surfaces stderr, matching how `BerksfileCheck` handles a failed run.

Closes #884.