### PR TITLE
Fix Solargraph regexp capture warning

### DIFF
--- a/lib/overcommit/hook/pre_commit/solargraph.rb
+++ b/lib/overcommit/hook/pre_commit/solargraph.rb
@@ -10,7 +10,7 @@ module Overcommit
       #
       # @see https://github.com/castwide/solargraph
       class Solargraph < Base
-        MESSAGE_REGEX = /^\s*(?<file>(?:\w:)?[^:]+):(?<line>\d+)( -|:) /.freeze
+        MESSAGE_REGEX = /^\s*(?<file>(?:\w:)?[^:]+):(?<line>\d+)(?: -|:) /.freeze
 
         def run
           result = execute(command, args: applicable_files)


### PR DESCRIPTION
Change the Solargraph message regexp separator group to a non-capturing group to avoid RuboCop's Lint/MixedRegexpCaptureTypes warning while preserving existing named captures.