### PR TITLE
Require patched REXML version

### DIFF
--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency          'childprocess', '>= 0.6.3', '< 6'
   s.add_dependency          'iniparse', '~> 1.4'
-  s.add_dependency          'rexml', '>= 3.3.9'
+  s.add_dependency          'rexml', '>= 3.4.2'
 end


### PR DESCRIPTION
Fixes #874.

Raise the minimum REXML runtime dependency from 3.3.9 to 3.4.2, the first release containing the fix for CVE-2025-58767. This prevents downstream Bundler resolution from selecting an affected REXML release.